### PR TITLE
Harden assistant file path handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,4 @@ __pycache__
 !/data/agents/Chat酱/info.yaml
 data/last_used_agent.txt
 
-test*
 uv.lock

--- a/api/assistant_api.py
+++ b/api/assistant_api.py
@@ -1,8 +1,6 @@
-import os
-import re
-import shutil
-import zipfile
 import io
+import os
+import zipfile
 import base64
 from pathlib import Path
 from models.dto.assistant_request import (
@@ -17,6 +15,13 @@ from models.dto.assistant_request import (
 )
 
 from services.assistant_service import AssistantService
+from services.assistant_paths import (
+    AssistantAssetsZipError,
+    AssistantPathError,
+    replace_assets_from_zip,
+    resolve_assistant_dir,
+    resolve_assistant_file,
+)
 from utils.file_utils import get_latest_modification_time
 from fastapi import (
     APIRouter,
@@ -26,13 +31,16 @@ from fastapi import (
     Response,
     UploadFile,
 )
-from Config import Config
 from utils.log import logger
 
 
 assistant_api = APIRouter()
 
 assistant_service = AssistantService()
+
+
+def _bad_assistant_path(exc: Exception) -> HTTPException:
+    return HTTPException(status_code=400, detail=str(exc))
 
 
 @assistant_api.get("/assistants")
@@ -120,6 +128,10 @@ async def switch_assistant(switch_request: SwitchAssistantRequest):
         }
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
+    except AssistantPathError as e:
+        raise _bad_assistant_path(e)
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"切换助手失败: {str(e)}")
         raise HTTPException(status_code=500, detail=f"切换助手失败: {str(e)}")
@@ -139,19 +151,21 @@ async def check_assets_update(
     Returns:
         包含是否需要更新的信息
     """
-    # 构建助手目录路径
-    assistant_dir = os.path.join(Config.BASE_AGENTS_PATH, assistant_assets_check.name)
-    assets_dir = os.path.join(assistant_dir, "assets")
-
-    # 检查助手是否存在
-    if not os.path.exists(assistant_dir):
+    try:
+        assistant_dir = resolve_assistant_dir(
+            assistant_assets_check.name, must_exist=True
+        )
+    except AssistantPathError as e:
+        raise _bad_assistant_path(e)
+    except FileNotFoundError:
         raise HTTPException(
             status_code=404,
             detail=f"Assistant '{assistant_assets_check.name}' not found",
         )
+    assets_dir = assistant_dir / "assets"
 
     # 检查assets目录是否存在
-    if not os.path.exists(assets_dir):
+    if not assets_dir.exists():
         return {
             "msg": "Assets directory not found",
             "needsUpdate": False,
@@ -182,24 +196,24 @@ async def download_assets(assistant_assets_download: AssistantAssetsDownloadRequ
     Returns:
         zip格式的资源文件
     """
-    # 构建助手目录路径
-    assistant_dir = os.path.join(
-        Config.BASE_AGENTS_PATH, assistant_assets_download.name
-    )
-    assets_dir = os.path.join(assistant_dir, "assets")
-
-    # 检查助手是否存在
-    if not os.path.exists(assistant_dir):
+    try:
+        assistant_dir = resolve_assistant_dir(
+            assistant_assets_download.name, must_exist=True
+        )
+    except AssistantPathError as e:
+        raise _bad_assistant_path(e)
+    except FileNotFoundError:
         raise HTTPException(
             status_code=404,
-            detail=f"Assistant '{ assistant_assets_download.name}' not found",
+            detail=f"Assistant '{assistant_assets_download.name}' not found",
         )
+    assets_dir = assistant_dir / "assets"
 
     # 检查assets目录是否存在
-    if not os.path.exists(assets_dir):
+    if not assets_dir.exists():
         raise HTTPException(
             status_code=404,
-            detail=f"Assets directory not found for assistant '{ assistant_assets_download.name}'",
+            detail=f"Assets directory not found for assistant '{assistant_assets_download.name}'",
         )
 
     # 创建内存中的zip文件
@@ -207,9 +221,8 @@ async def download_assets(assistant_assets_download: AssistantAssetsDownloadRequ
 
     # 遍历assets目录，添加文件到zip
     with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zip_file:
-        assets_path = Path(assets_dir)
         # 检查目录是否为空
-        if not any(assets_path.iterdir()):
+        if not any(assets_dir.iterdir()):
             # 如果目录为空
             raise HTTPException(
                 status_code=404,
@@ -218,11 +231,12 @@ async def download_assets(assistant_assets_download: AssistantAssetsDownloadRequ
         else:
             # 添加所有文件
             for root, _, files in os.walk(assets_dir):
+                root_path = Path(root)
                 for file in files:
-                    file_path = os.path.join(root, file)
+                    file_path = root_path / file
                     # 计算相对路径，保持目录结构
-                    rel_path = os.path.relpath(file_path, os.path.dirname(assets_dir))
-                    zip_file.write(file_path, rel_path)
+                    rel_path = file_path.relative_to(assistant_dir)
+                    zip_file.write(file_path, rel_path.as_posix())
 
     # 重置文件指针
     zip_buffer.seek(0)
@@ -250,27 +264,6 @@ async def upload_assets(
     Returns:
         上传成功的消息
     """
-    # 验证助手名称合法性
-    if not name or not re.match(r"^[a-zA-Z0-9_\u4e00-\u9fa5]+$", name):
-        raise HTTPException(status_code=400, detail="Invalid assistant name format")
-
-    # 防止路径遍历攻击
-    safe_name = os.path.basename(name)
-    if safe_name != name:
-        raise HTTPException(status_code=400, detail="Invalid assistant name")
-    # 构建助手目录路径
-    assistant_dir = os.path.join(Config.BASE_AGENTS_PATH, safe_name)
-
-    # 检查助手是否存在
-    if not os.path.exists(assistant_dir):
-        raise HTTPException(
-            status_code=404,
-            detail=f"Assistant '{safe_name}' not found",
-        )
-
-    # 构建assets目录路径
-    assets_dir = os.path.join(assistant_dir, "assets")
-
     # 读取上传的文件内容
     try:
         # 读取zip文件内容
@@ -282,63 +275,27 @@ async def upload_assets(
                 status_code=400, detail="Uploaded file is not a valid zip file"
             )
 
-        # 如果原assets目录存在，先删除
-        if os.path.exists(assets_dir):
-            shutil.rmtree(assets_dir)
+        replace_assets_from_zip(name, zip_content)
 
-        # 创建新的assets目录
-        os.makedirs(assets_dir, exist_ok=True)
-
-        # 直接从zip文件中提取assets目录内容
-        with zipfile.ZipFile(io.BytesIO(zip_content), "r") as zip_ref:
-            # 获取zip文件中的所有文件列表
-            zip_contents = zip_ref.namelist()
-
-            # 检查是否包含assets目录
-            has_assets_dir = any(item.startswith("assets/") for item in zip_contents)
-
-            # 提取文件到目标目录
-            for item in zip_contents:
-                # 跳过目录项
-                if item.endswith("/"):
-                    continue
-
-                if has_assets_dir:
-                    # 如果zip中包含assets目录，需要去掉这个前缀
-                    if item.startswith("assets/"):
-                        # 去掉assets/前缀，保留剩余路径
-                        target_path = os.path.join(assets_dir, item[7:])
-                        # 确保目标文件的目录存在
-                        os.makedirs(os.path.dirname(target_path), exist_ok=True)
-                        # 提取文件
-                        with (
-                            zip_ref.open(item) as source,
-                            open(target_path, "wb") as target,
-                        ):
-                            target.write(source.read())
-                else:
-                    # 如果zip中不包含assets目录，直接提取到assets目录
-                    target_path = os.path.join(assets_dir, item)
-                    # 确保目标文件的目录存在
-                    os.makedirs(os.path.dirname(target_path), exist_ok=True)
-                    # 提取文件
-                    with (
-                        zip_ref.open(item) as source,
-                        open(target_path, "wb") as target,
-                    ):
-                        target.write(source.read())
-
-        logger.info(f"Successfully uploaded assets for assistant: {safe_name}")
+        logger.info(f"Successfully uploaded assets for assistant: {name}")
 
         return {
             "status": "success",
-            "message": f"Assets uploaded successfully for assistant '{safe_name}'",
+            "message": f"Assets uploaded successfully for assistant '{name}'",
         }
 
     except zipfile.BadZipFile:
         raise HTTPException(status_code=400, detail="Invalid zip file format")
+    except HTTPException:
+        raise
+    except AssistantPathError as e:
+        raise _bad_assistant_path(e)
+    except AssistantAssetsZipError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail=f"Assistant '{name}' not found")
     except Exception as e:
-        logger.error(f"Error uploading assets for assistant {safe_name}: {str(e)}")
+        logger.error(f"Error uploading assets for assistant {name}: {str(e)}")
         raise HTTPException(
             status_code=500, detail=f"Failed to upload assets: {str(e)}"
         )
@@ -359,6 +316,8 @@ async def update_assistant(update_request: UpdateAssistantRequest):
         }
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
+    except AssistantPathError as e:
+        raise _bad_assistant_path(e)
     except Exception as e:
         logger.error(f"更新助手信息失败: {str(e)}")
         raise HTTPException(status_code=500, detail=f"更新助手信息失败: {str(e)}")
@@ -395,6 +354,8 @@ async def delete_assistant(delete_request: DeleteAssistantRequest):
         return {"msg": f"助手 '{delete_request.name}' 删除成功"}
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
+    except AssistantPathError as e:
+        raise _bad_assistant_path(e)
     except Exception as e:
         logger.error(f"删除助手失败: {str(e)}")
         raise HTTPException(status_code=500, detail=f"删除助手失败: {str(e)}")
@@ -403,13 +364,15 @@ async def delete_assistant(delete_request: DeleteAssistantRequest):
 @assistant_api.post("/assistant/info/avatar")
 async def get_assistant_avatar(get_request: GetAssistantAvatar):
     try:
-        avatar_bytes = b""
-        with open(f"data/agents/{get_request.name}/avatar", "rb") as f:
+        avatar_path = resolve_assistant_file(get_request.name, "avatar", must_exist=True)
+        with avatar_path.open("rb") as f:
             avatar_bytes = f.read()
         avatar_base64 = base64.b64encode(avatar_bytes).decode("utf-8")
         return {"msg": "获取助手头像成功", "data": avatar_base64}
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
+    except AssistantPathError as e:
+        raise _bad_assistant_path(e)
     except Exception as e:
         logger.error(f"获取助手头像失败: {str(e)}")
         raise HTTPException(status_code=500, detail=f"获取助手头像失败: {str(e)}")
@@ -418,13 +381,15 @@ async def get_assistant_avatar(get_request: GetAssistantAvatar):
 @assistant_api.post("/assistant/upload/avatar")
 async def upload_assistant_avatar(data: UploadAssistantAvatar):
     try:
-        avatar_data = base64.b64decode(data.data)
-        avatar_path = f"data/agents/{data.name}/avatar"
-        with open(avatar_path, "wb") as f:
+        avatar_data = base64.b64decode(data.data, validate=True)
+        avatar_path = resolve_assistant_file(data.name, "avatar")
+        with avatar_path.open("wb") as f:
             f.write(avatar_data)
         return {"msg": "上传助手头像成功"}
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
+    except (AssistantPathError, ValueError) as e:
+        raise _bad_assistant_path(e)
     except Exception as e:
         logger.error(f"上传助手头像失败: {str(e)}")
         raise HTTPException(status_code=500, detail=f"上传助手头像失败: {str(e)}")

--- a/services/assistant_paths.py
+++ b/services/assistant_paths.py
@@ -1,0 +1,192 @@
+import io
+import os
+import shutil
+import tempfile
+import zipfile
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from uuid import uuid4
+
+from Config import Config
+
+
+MAX_ASSISTANT_NAME_LENGTH = 128
+MAX_ASSETS_ZIP_BYTES = 256 * 1024 * 1024
+MAX_ASSETS_TOTAL_BYTES = 512 * 1024 * 1024
+MAX_ASSET_FILE_BYTES = 128 * 1024 * 1024
+MAX_ASSET_FILE_COUNT = 5000
+
+
+class AssistantPathError(ValueError):
+    """Raised when an assistant name or derived path escapes data/agents."""
+
+
+class AssistantAssetsZipError(ValueError):
+    """Raised when an uploaded assets zip is unsafe or malformed."""
+
+
+def agents_root() -> Path:
+    return Path(Config.BASE_AGENTS_PATH).resolve()
+
+
+def validate_assistant_name(name: str) -> str:
+    if not isinstance(name, str):
+        raise AssistantPathError("Assistant name must be a string")
+    if not name or name != name.strip():
+        raise AssistantPathError("Assistant name cannot be empty or padded")
+    if len(name) > MAX_ASSISTANT_NAME_LENGTH:
+        raise AssistantPathError("Assistant name is too long")
+    if "\x00" in name or any(ord(char) < 32 for char in name):
+        raise AssistantPathError("Assistant name contains control characters")
+    if "/" in name or "\\" in name:
+        raise AssistantPathError("Assistant name cannot contain path separators")
+    if name in {".", ".."}:
+        raise AssistantPathError("Assistant name cannot be a relative path segment")
+    if Path(name).is_absolute() or PureWindowsPath(name).is_absolute():
+        raise AssistantPathError("Assistant name cannot be an absolute path")
+    return name
+
+
+def _ensure_under_root(path: Path, root: Path) -> Path:
+    resolved = path.resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise AssistantPathError(f"Resolved path escapes assistants root: {path}") from exc
+    return resolved
+
+
+def resolve_assistant_dir(name: str, *, must_exist: bool = False) -> Path:
+    safe_name = validate_assistant_name(name)
+    root = agents_root()
+    assistant_dir = _ensure_under_root(root / safe_name, root)
+    if must_exist and not assistant_dir.is_dir():
+        raise FileNotFoundError(f"Assistant '{safe_name}' not found")
+    return assistant_dir
+
+
+def resolve_assistant_file(
+    name: str, *relative_parts: str, must_exist: bool = False
+) -> Path:
+    assistant_dir = resolve_assistant_dir(name, must_exist=True)
+    target = _ensure_under_root(assistant_dir.joinpath(*relative_parts), assistant_dir)
+    if must_exist and not target.is_file():
+        raise FileNotFoundError(f"Assistant file not found: {target.name}")
+    return target
+
+
+def _is_zip_symlink(info: zipfile.ZipInfo) -> bool:
+    return ((info.external_attr >> 16) & 0o170000) == 0o120000
+
+
+def _remove_path(path: Path) -> None:
+    if path.is_dir():
+        shutil.rmtree(path)
+    elif path.exists():
+        path.unlink()
+
+
+def _normalise_asset_member(
+    info: zipfile.ZipInfo, *, has_assets_dir: bool, assets_dir: Path
+) -> tuple[zipfile.ZipInfo, Path] | None:
+    filename = info.filename
+    if not filename or "\x00" in filename or "\\" in filename:
+        raise AssistantAssetsZipError(f"Unsafe zip member name: {filename!r}")
+    if PureWindowsPath(filename).is_absolute():
+        raise AssistantAssetsZipError(f"Absolute zip member is not allowed: {filename}")
+    if _is_zip_symlink(info):
+        raise AssistantAssetsZipError(f"Symlink zip member is not allowed: {filename}")
+
+    member_path = PurePosixPath(filename)
+    if member_path.is_absolute() or any(part in {"", ".", ".."} for part in member_path.parts):
+        raise AssistantAssetsZipError(f"Path traversal zip member is not allowed: {filename}")
+
+    if has_assets_dir:
+        if not member_path.parts or member_path.parts[0] != "assets":
+            return None
+        relative_parts = member_path.parts[1:]
+    else:
+        relative_parts = member_path.parts
+
+    if not relative_parts:
+        return None
+
+    target = assets_dir.joinpath(*relative_parts).resolve()
+    try:
+        target.relative_to(assets_dir.resolve())
+    except ValueError as exc:
+        raise AssistantAssetsZipError(f"Zip member escapes assets directory: {filename}") from exc
+    return info, target
+
+
+def replace_assets_from_zip(name: str, zip_content: bytes) -> Path:
+    if len(zip_content) > MAX_ASSETS_ZIP_BYTES:
+        raise AssistantAssetsZipError("Uploaded zip is too large")
+
+    assistant_dir = resolve_assistant_dir(name, must_exist=True)
+    assets_dir = assistant_dir / "assets"
+    temp_root = Path(
+        tempfile.mkdtemp(prefix=".assets-upload-", dir=str(assistant_dir))
+    ).resolve()
+    temp_assets_dir = temp_root / "assets"
+    temp_assets_dir.mkdir()
+    backup_dir = assistant_dir / f".assets-backup-{uuid4().hex}"
+    moved_existing = False
+
+    try:
+        with zipfile.ZipFile(io.BytesIO(zip_content), "r") as zip_ref:
+            infos = zip_ref.infolist()
+            has_assets_dir = any(
+                PurePosixPath(info.filename).parts[:1] == ("assets",)
+                for info in infos
+            )
+            planned: list[tuple[zipfile.ZipInfo, Path]] = []
+            planned_targets: set[Path] = set()
+            total_size = 0
+
+            for info in infos:
+                if info.is_dir():
+                    continue
+                if info.file_size > MAX_ASSET_FILE_BYTES:
+                    raise AssistantAssetsZipError(
+                        f"Zip member is too large: {info.filename}"
+                    )
+                total_size += info.file_size
+                if total_size > MAX_ASSETS_TOTAL_BYTES:
+                    raise AssistantAssetsZipError("Uncompressed assets are too large")
+                item = _normalise_asset_member(
+                    info, has_assets_dir=has_assets_dir, assets_dir=temp_assets_dir
+                )
+                if item:
+                    if item[1] in planned_targets:
+                        raise AssistantAssetsZipError(
+                            f"Duplicate zip target is not allowed: {info.filename}"
+                        )
+                    planned_targets.add(item[1])
+                    planned.append(item)
+
+            if not planned:
+                raise AssistantAssetsZipError("Zip does not contain asset files")
+            if len(planned) > MAX_ASSET_FILE_COUNT:
+                raise AssistantAssetsZipError("Zip contains too many asset files")
+
+            for info, target in planned:
+                target.parent.mkdir(parents=True, exist_ok=True)
+                with zip_ref.open(info) as source, target.open("wb") as dest:
+                    shutil.copyfileobj(source, dest)
+
+        if assets_dir.exists():
+            os.replace(assets_dir, backup_dir)
+            moved_existing = True
+        os.replace(temp_assets_dir, assets_dir)
+        if moved_existing:
+            _remove_path(backup_dir)
+        return assets_dir
+    except Exception:
+        if moved_existing and not assets_dir.exists() and backup_dir.exists():
+            os.replace(backup_dir, assets_dir)
+        raise
+    finally:
+        if temp_root.exists():
+            shutil.rmtree(temp_root, ignore_errors=True)
+        if backup_dir.exists():
+            _remove_path(backup_dir)

--- a/services/assistant_service.py
+++ b/services/assistant_service.py
@@ -9,6 +9,11 @@ import yaml
 from Config import Config
 from models.dto.assistant_request import AddAssistantRequest, UpdateAssistantRequest
 from models.types.assistant_info import AssistantInfo
+from services.assistant_paths import (
+    agents_root,
+    resolve_assistant_dir,
+    validate_assistant_name,
+)
 from utils.agent import Agent
 from utils.file_utils import get_latest_modification_time
 from utils import prompt
@@ -56,22 +61,26 @@ class AssistantService:
         """
         加载全部助手信息
         """
-        assistants_path = Config.BASE_AGENTS_PATH
         assistants: list[AssistantInfo] = []
 
         # 确保路径存在
-        if not os.path.exists(assistants_path):
+        assistants_path = agents_root()
+        if not assistants_path.exists():
             Log.logger.warning(f"助手路径不存在: {assistants_path}")
             raise FileNotFoundError(f"助手路径不存在: {assistants_path}")
 
         for dirname in os.listdir(assistants_path):
-            file_path = os.path.join(assistants_path, dirname, "info.yaml")
-            if os.path.isfile(file_path):
-                with open(file_path, "r", encoding="utf-8") as f:
+            try:
+                assistant_dir = resolve_assistant_dir(dirname, must_exist=True)
+            except ValueError as e:
+                Log.logger.warning(f"跳过非法助手目录 {dirname}: {e}")
+                continue
+            file_path = assistant_dir / "info.yaml"
+            if file_path.is_file():
+                with file_path.open("r", encoding="utf-8") as f:
                     assistant = yaml.safe_load(f)
                     # 添加最后修改时间信息，用于检查更新
-                    assistant_dir = os.path.join(assistants_path, dirname)
-                    assets_dir = os.path.join(assistant_dir, "assets")
+                    assets_dir = assistant_dir / "assets"
 
                     # 获取最后修改时间
                     if os.path.exists(assets_dir):
@@ -94,17 +103,15 @@ class AssistantService:
         """
         更新助手信息
         """
-        assistants_path = Config.BASE_AGENTS_PATH
-        # 使用助手名称作为目录名
-        assistant_dir = os.path.join(assistants_path, update_request.name)
-        info_file_path = os.path.join(assistant_dir, "info.yaml")
+        assistant_dir = resolve_assistant_dir(update_request.name, must_exist=True)
+        info_file_path = assistant_dir / "info.yaml"
 
         # 检查助手是否存在
-        if not os.path.exists(assistant_dir) or not os.path.isfile(info_file_path):
+        if not info_file_path.is_file():
             raise FileNotFoundError(f"助手 '{update_request.name}' 不存在")
 
         # 读取现有信息
-        with open(info_file_path, "r", encoding="utf-8") as f:
+        with info_file_path.open("r", encoding="utf-8") as f:
             existing_info = yaml.safe_load(f)
 
         # 更新信息（只更新非None字段）
@@ -115,7 +122,7 @@ class AssistantService:
         existing_info["updatedAt"] = int(time.time())
 
         # 获取assets最后修改时间
-        assets_dir = os.path.join(assistant_dir, "assets")
+        assets_dir = assistant_dir / "assets"
 
         if os.path.exists(assets_dir):
             existing_info["assetsLastModified"] = get_latest_modification_time(
@@ -125,7 +132,7 @@ class AssistantService:
             existing_info["assetsLastModified"] = 0
 
         # 保存更新后的信息
-        with open(info_file_path, "w", encoding="utf-8") as f:
+        with info_file_path.open("w", encoding="utf-8") as f:
             yaml.dump(existing_info, f, allow_unicode=True, default_flow_style=False)
 
         # 更新缓存
@@ -142,23 +149,19 @@ class AssistantService:
         """
         添加新助手
         """
-        assistants_path = Config.BASE_AGENTS_PATH
-        # 使用助手名称作为目录名
-        assistant_dir = os.path.join(assistants_path, add_request.name)
-        info_file_path = os.path.join(assistant_dir, "info.yaml")
-
-        if not add_request.name:
-            raise ValueError("助手名称不能为空")
+        safe_name = validate_assistant_name(add_request.name)
+        assistant_dir = resolve_assistant_dir(safe_name)
+        info_file_path = assistant_dir / "info.yaml"
 
         # 检查助手是否已存在
-        if os.path.exists(assistant_dir):
-            raise ValueError(f"助手 '{add_request.name}' 已存在")
+        if assistant_dir.exists():
+            raise ValueError(f"助手 '{safe_name}' 已存在")
 
         # 创建助手目录和必要的子目录
-        os.makedirs(assistant_dir, exist_ok=True)
-        os.makedirs(os.path.join(assistant_dir, "assets"), exist_ok=True)
-        os.makedirs(os.path.join(assistant_dir, "memory"), exist_ok=True)
-        os.makedirs(os.path.join(assistant_dir, "data_base"), exist_ok=True)
+        assistant_dir.mkdir(parents=True, exist_ok=True)
+        (assistant_dir / "assets").mkdir(exist_ok=True)
+        (assistant_dir / "memory").mkdir(exist_ok=True)
+        (assistant_dir / "data_base").mkdir(exist_ok=True)
 
         special_settings = {
             "firstMeetTime": int(time.time()),
@@ -173,7 +176,7 @@ class AssistantService:
         }
 
         # 保存助手信息
-        with open(info_file_path, "w", encoding="utf-8") as f:
+        with info_file_path.open("w", encoding="utf-8") as f:
             yaml.dump(assistant_info, f, allow_unicode=True, default_flow_style=False)
 
         # 更新缓存
@@ -186,13 +189,7 @@ class AssistantService:
         """
         删除助手
         """
-        assistants_path = Config.BASE_AGENTS_PATH
-        # 使用助手名称作为目录名
-        assistant_dir = os.path.join(assistants_path, assistant_name)
-
-        # 检查助手是否存在
-        if not os.path.exists(assistant_dir):
-            raise FileNotFoundError(f"助手 '{assistant_name}' 不存在")
+        assistant_dir = resolve_assistant_dir(assistant_name, must_exist=True)
 
         # 如果当前正在使用该助手，先释放
         if self.current_assistant_name == assistant_name:
@@ -222,10 +219,9 @@ class AssistantService:
             FileNotFoundError: 当助手不存在时
         """
         # 检查助手配置文件是否存在
-        assistant_info_path = os.path.join(
-            Config.BASE_AGENTS_PATH, assistant_name, "info.yaml"
-        )
-        if not os.path.exists(assistant_info_path):
+        assistant_dir = resolve_assistant_dir(assistant_name, must_exist=True)
+        assistant_info_path = assistant_dir / "info.yaml"
+        if not assistant_info_path.exists():
             raise FileNotFoundError(f"助手 '{assistant_name}' 不存在")
 
         # 检查助手是否已经加载
@@ -348,17 +344,18 @@ class AssistantService:
             return self.assistants_cache[assistant_name]
 
         # 如果缓存中没有，尝试加载
-        file_path = os.path.join(Config.BASE_AGENTS_PATH, assistant_name, "info.yaml")
+        try:
+            assistant_dir = resolve_assistant_dir(assistant_name, must_exist=True)
+        except (FileNotFoundError, ValueError):
+            return None
+        file_path = assistant_dir / "info.yaml"
 
-        if os.path.isfile(file_path):
+        if file_path.is_file():
             try:
-                with open(file_path, "r", encoding="utf-8") as f:
+                with file_path.open("r", encoding="utf-8") as f:
                     assistant = yaml.safe_load(f)
                     # 添加最后修改时间信息
-                    assistant_dir = os.path.join(
-                        Config.BASE_AGENTS_PATH, assistant_name
-                    )
-                    assets_dir = os.path.join(assistant_dir, "assets")
+                    assets_dir = assistant_dir / "assets"
 
                     if os.path.exists(assets_dir):
                         assistant["assetsLastModified"] = get_latest_modification_time(

--- a/tests/test_assistant_paths.py
+++ b/tests/test_assistant_paths.py
@@ -1,0 +1,83 @@
+import io
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+from Config import Config
+from services.assistant_paths import (
+    AssistantAssetsZipError,
+    AssistantPathError,
+    replace_assets_from_zip,
+    resolve_assistant_dir,
+    validate_assistant_name,
+)
+
+
+class AssistantPathTests(unittest.TestCase):
+    def setUp(self):
+        self._old_agents_path = Config.BASE_AGENTS_PATH
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name) / "data" / "agents"
+        self.root.mkdir(parents=True)
+        Config.BASE_AGENTS_PATH = str(self.root)
+
+    def tearDown(self):
+        Config.BASE_AGENTS_PATH = self._old_agents_path
+        self.tmp.cleanup()
+
+    def make_assistant(self, name="Chat"):
+        assistant_dir = self.root / name
+        (assistant_dir / "assets").mkdir(parents=True)
+        return assistant_dir
+
+    def make_zip(self, entries):
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zip_file:
+            for name, content in entries.items():
+                zip_file.writestr(name, content)
+        return buffer.getvalue()
+
+    def test_rejects_path_like_assistant_names(self):
+        for name in ("../evil", "a/b", "a\\b", "/tmp/evil", "", " padded "):
+            with self.subTest(name=name):
+                with self.assertRaises(AssistantPathError):
+                    validate_assistant_name(name)
+
+    def test_rejects_symlink_escape_from_agents_root(self):
+        outside = Path(self.tmp.name) / "outside"
+        outside.mkdir()
+        (self.root / "Linked").symlink_to(outside, target_is_directory=True)
+
+        with self.assertRaises(AssistantPathError):
+            resolve_assistant_dir("Linked", must_exist=True)
+
+    def test_rejects_zip_slip_without_replacing_existing_assets(self):
+        assistant_dir = self.make_assistant()
+        existing = assistant_dir / "assets" / "keep.txt"
+        existing.write_text("keep", encoding="utf-8")
+        payload = self.make_zip({"assets/../data_base/tmp/labels/payload.pkl": b"x"})
+
+        with self.assertRaises(AssistantAssetsZipError):
+            replace_assets_from_zip("Chat", payload)
+
+        self.assertEqual(existing.read_text(encoding="utf-8"), "keep")
+        self.assertFalse((assistant_dir / "data_base" / "tmp" / "labels" / "payload.pkl").exists())
+
+    def test_replaces_assets_with_safe_zip_members_only(self):
+        assistant_dir = self.make_assistant()
+        (assistant_dir / "assets" / "old.txt").write_text("old", encoding="utf-8")
+        payload = self.make_zip({
+            "assets/images/avatar.png": b"png",
+            "ignored.txt": b"ignored",
+        })
+
+        replace_assets_from_zip("Chat", payload)
+
+        self.assertFalse((assistant_dir / "assets" / "old.txt").exists())
+        self.assertEqual((assistant_dir / "assets" / "images" / "avatar.png").read_bytes(), b"png")
+        self.assertFalse((assistant_dir / "assets" / "ignored.txt").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/data_base.py
+++ b/utils/data_base.py
@@ -1,7 +1,7 @@
+import json
 import os
 import yaml
 import hashlib
-import pickle
 import numpy as np
 import faiss
 from utils import embedding
@@ -9,6 +9,10 @@ from utils import log as Log
 from models.types.assistant_info import AssistantInfo
 
 os.environ["KMP_DUPLICATE_LIB_OK"] = "TRUE"
+
+
+def _cache_path(labels_dir: str, book_name: str) -> str:
+    return os.path.join(labels_dir, f"{book_name}.json")
 
 
 def _sum_md5(file_path: str):
@@ -37,14 +41,16 @@ class DataBase:
         self.databases = []
 
         # 如果不存在创建数据库目录
-        os.makedirs(self.path + "/tmp/labels", exist_ok=True)
+        labels_dir = f"{self.path}/tmp/labels"
+        os.makedirs(labels_dir, exist_ok=True)
 
         base_list = {}
         # 如果存在标签文件，加载标签
         if os.path.exists(self.path + "/tmp/label.yaml"):
             with open(self.path + "/tmp/label.yaml", "r", encoding="utf-8") as f:
-                if base_list:
-                    base_list = yaml.safe_load(f)
+                loaded_base_list = yaml.safe_load(f) or {}
+                if isinstance(loaded_base_list, dict):
+                    base_list = loaded_base_list
         # 搜索世界书目录下的所有文件
         file_list = os.listdir(self.path)
         books = []
@@ -54,7 +60,12 @@ class DataBase:
             file_path = os.path.join(self.path, file)
             if os.path.isfile(file_path):
                 f_md5 = _sum_md5(file_path)
-                if file not in base_list or base_list[file] != f_md5:
+                cache_file = _cache_path(labels_dir, file)
+                if (
+                    file not in base_list
+                    or base_list[file] != f_md5
+                    or not os.path.exists(cache_file)
+                ):
                     books.append(file)
                     books_path.append(file_path)
 
@@ -69,10 +80,16 @@ class DataBase:
                         tmp1.append(data_key)
                         tmp2.append(data[data_key])
                     vect_list = embedding.t2vect(tmp1)
-                    res_data = {"vect": vect_list, "text": tmp2}
-                    pick_data = pickle.dumps(res_data)
-                    with open(f"{self.path}/tmp/labels/{books[index]}.pkl", "wb") as f2:
-                        f2.write(pick_data)
+                    res_data = {
+                        "vect": np.asarray(vect_list, dtype=np.float32).tolist(),
+                        "text": tmp2,
+                    }
+                    with open(
+                        _cache_path(labels_dir, books[index]),
+                        "w",
+                        encoding="utf-8",
+                    ) as f2:
+                        json.dump(res_data, f2, ensure_ascii=False)
                     Log.logger.info(
                         f"成功向量化【{books[index]}】世界书，共加载{len(tmp1)}条数据。"
                     )
@@ -82,17 +99,23 @@ class DataBase:
                     base_list[books[index]] = _sum_md5(books_path[index])
 
         # 加载向量，建立数据库、索引，并保存，更新总表内容
-        file_list = os.listdir(f"{self.path}/tmp/labels")
+        file_list = os.listdir(labels_dir)
         tmp_list = []
         for file in file_list:
-            if not os.path.isfile(f"{self.path}/tmp/labels/{file}"):
+            if not file.endswith(".json"):
                 continue
-            with open(f"{self.path}/tmp/labels/{file}", "rb") as f:
-                tmp_data = pickle.load(f)
-            tmp_list.append(tmp_data["vect"])
+            cache_file = os.path.join(labels_dir, file)
+            if not os.path.isfile(cache_file):
+                continue
+            with open(cache_file, "r", encoding="utf-8") as f:
+                tmp_data = json.load(f)
+            vect = np.asarray(tmp_data["vect"], dtype=np.float32)
+            if vect.ndim == 1:
+                vect = np.expand_dims(vect, axis=0)
+            tmp_list.append(vect)
             self.databases += tmp_data["text"]
             Log.logger.info(
-                f"成功加载【{file}】世界书，共加载{len(tmp_data['vect'])}条数据。"
+                f"成功加载【{file}】世界书，共加载{len(vect)}条数据。"
             )
         with open(f"{self.path}/tmp/label.yaml", "w") as f:
             yaml.safe_dump(base_list, f)

--- a/utils/long_mem.py
+++ b/utils/long_mem.py
@@ -6,7 +6,6 @@ from utils import embedding, prompt
 from ruamel.yaml import YAML
 from ruamel.yaml.scalarstring import LiteralScalarString
 import numpy as np
-import pickle
 import requests
 import jionlp
 from bisect import bisect_left, bisect_right


### PR DESCRIPTION
## Summary
- add a single assistant path resolver that rejects path-like assistant names and symlink escapes
- harden assistant asset upload against Zip Slip, symlink entries, duplicate targets, and oversized archives
- stop loading world-book cache files with pickle; use JSON vector cache instead
- add targeted regression tests for path traversal, symlink escape, and malicious assets zips

## Verification
- PYTHONDONTWRITEBYTECODE=1 python3 -m compileall api/assistant_api.py services/assistant_paths.py services/assistant_service.py utils/data_base.py utils/long_mem.py tests/test_assistant_paths.py
- PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests.test_assistant_paths
- git diff --check