### PR TITLE
Use safe local network defaults

### DIFF
--- a/checks/network_defaults_check.py
+++ b/checks/network_defaults_check.py
@@ -1,0 +1,37 @@
+import os
+import unittest
+from unittest.mock import patch
+
+import server_settings
+
+
+class NetworkDefaultsCheck(unittest.TestCase):
+    def test_defaults_are_localhost_only(self):
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(server_settings.get_web_host(), "127.0.0.1")
+            self.assertEqual(server_settings.get_socket_host(), "127.0.0.1")
+            self.assertEqual(
+                server_settings.get_cors_origins(),
+                ["http://127.0.0.1:8001", "http://localhost:8001"],
+            )
+
+    def test_remote_access_requires_explicit_environment(self):
+        env = {
+            "MOECHAT_HOST": "0.0.0.0",
+            "MOECHAT_SOCKET_HOST": "0.0.0.0",
+            "MOECHAT_CORS_ORIGINS": "http://example.local:8001, http://127.0.0.1:8001",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            self.assertEqual(server_settings.get_web_host(), "0.0.0.0")
+            self.assertEqual(server_settings.get_socket_host(), "0.0.0.0")
+            self.assertEqual(
+                server_settings.get_cors_origins(),
+                ["http://example.local:8001", "http://127.0.0.1:8001"],
+            )
+
+    def test_wildcard_cors_disables_credentials(self):
+        self.assertFalse(server_settings.cors_allows_credentials(["*"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/doc/README_zh.md
+++ b/doc/README_zh.md
@@ -101,6 +101,16 @@ uv sync
 uv run main_web.py
 ```
 
+> 默认情况下，MoeChat 只监听本机 `127.0.0.1`。如果确实需要局域网访问，请显式设置
+> `MOECHAT_HOST`、`MOECHAT_SOCKET_HOST` 和 `MOECHAT_CORS_ORIGINS`，例如只允许你的前端来源：
+>
+> ```bash
+> MOECHAT_HOST=0.0.0.0 \
+> MOECHAT_SOCKET_HOST=0.0.0.0 \
+> MOECHAT_CORS_ORIGINS=http://192.168.1.10:8001 \
+> uv run main_web.py
+> ```
+
 ## 客户端使用方法
 
 感谢三三 sama 为 MoeChat 提供客户端支持。

--- a/main_web.py
+++ b/main_web.py
@@ -4,15 +4,30 @@ from web.src.router.router import app
 import uvicorn
 from threading import Thread
 from api.socket_api import start_socket_server
+from server_settings import (
+    get_socket_host,
+    get_socket_port,
+    get_web_host,
+    get_web_port,
+)
 
 
 def start_server():
+    web_host = get_web_host()
+    web_port = get_web_port()
+    socket_host = get_socket_host()
+    socket_port = get_socket_port()
+
     # 等待初始化完成
     asyncio.get_event_loop().run_until_complete(init())
     # 启动socket服务
-    Thread(target=start_socket_server, args=("0.0.0.0", 8002), daemon=True).start()
+    Thread(
+        target=start_socket_server,
+        args=(socket_host, socket_port),
+        daemon=True,
+    ).start()
     # 启动web服务，应该在最后
-    uvicorn.run(app, host="0.0.0.0", port=8001)
+    uvicorn.run(app, host=web_host, port=web_port)
 
 
 if __name__ == "__main__":

--- a/server_settings.py
+++ b/server_settings.py
@@ -1,0 +1,44 @@
+import os
+
+
+DEFAULT_WEB_HOST = "127.0.0.1"
+DEFAULT_WEB_PORT = 8001
+DEFAULT_SOCKET_PORT = 8002
+DEFAULT_CORS_ORIGINS = (
+    "http://127.0.0.1:8001",
+    "http://localhost:8001",
+)
+
+
+def env_int(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, default))
+    except ValueError:
+        return default
+
+
+def get_web_host() -> str:
+    return os.getenv("MOECHAT_HOST", DEFAULT_WEB_HOST)
+
+
+def get_web_port() -> int:
+    return env_int("MOECHAT_PORT", DEFAULT_WEB_PORT)
+
+
+def get_socket_host() -> str:
+    return os.getenv("MOECHAT_SOCKET_HOST", get_web_host())
+
+
+def get_socket_port() -> int:
+    return env_int("MOECHAT_SOCKET_PORT", DEFAULT_SOCKET_PORT)
+
+
+def get_cors_origins() -> list[str]:
+    raw_origins = os.getenv("MOECHAT_CORS_ORIGINS")
+    if raw_origins:
+        return [origin.strip() for origin in raw_origins.split(",") if origin.strip()]
+    return list(DEFAULT_CORS_ORIGINS)
+
+
+def cors_allows_credentials(origins: list[str]) -> bool:
+    return "*" not in origins

--- a/web/src/router/router.py
+++ b/web/src/router/router.py
@@ -3,14 +3,17 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from web.src.router.api_router import api_router
 from web.src.controller.controller import templates
+from server_settings import cors_allows_credentials, get_cors_origins
 
 # from core.external_server import router as models_router
 
+
+cors_origins = get_cors_origins()
 app = FastAPI()
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=True,
+    allow_origins=cors_origins,
+    allow_credentials=cors_allows_credentials(cors_origins),
     allow_methods=["*"],
     allow_headers=["*"],
 )


### PR DESCRIPTION
## Summary
- bind the FastAPI and raw socket servers to localhost by default instead of 0.0.0.0
- add explicit environment variables for remote access: MOECHAT_HOST, MOECHAT_PORT, MOECHAT_SOCKET_HOST, MOECHAT_SOCKET_PORT
- replace wildcard CORS defaults with localhost origins and allow explicit MOECHAT_CORS_ORIGINS
- document the remote-access opt-in path in the Chinese README
- add a lightweight unittest check for the network default behavior

## Verification
- PYTHONDONTWRITEBYTECODE=1 python3 -m compileall main_web.py web/src/router/router.py server_settings.py checks/network_defaults_check.py
- PYTHONDONTWRITEBYTECODE=1 python3 -m unittest checks.network_defaults_check
- git diff --check