### PR TITLE
Render chat messages without HTML injection

### DIFF
--- a/checks/frontend_security_check.js
+++ b/checks/frontend_security_check.js
@@ -1,0 +1,24 @@
+const fs = require("fs");
+
+const core = fs.readFileSync("web/resources/static/js/moechat_core.js", "utf8");
+const css = fs.readFileSync("web/resources/static/css/moechat_style.css", "utf8");
+
+const failures = [];
+
+if (core.includes("div.innerHTML =")) {
+  failures.push("appendMessage must not write user/model text through div.innerHTML");
+}
+if (!core.includes("document.createTextNode")) {
+  failures.push("appendMessage should render text through text nodes");
+}
+if (!core.includes('rainScript.src = "/js/rain_effect.js"')) {
+  failures.push("rain effect script path must point at /js/rain_effect.js");
+}
+if (!css.includes('url("/image/crack_overlay.png")')) {
+  failures.push("crack overlay CSS must point at /image/crack_overlay.png");
+}
+
+if (failures.length > 0) {
+  console.error(failures.join("\n"));
+  process.exit(1);
+}

--- a/web/resources/static/css/moechat_style.css
+++ b/web/resources/static/css/moechat_style.css
@@ -771,7 +771,7 @@ button#clearBtn {
   left: 0;
   width: 100vw;
   height: 100vh;
-  background: url("crack_overlay.png") center/cover no-repeat;
+  background: url("/image/crack_overlay.png") center/cover no-repeat;
   z-index: 9999;
   pointer-events: none;
   opacity: 0.75;

--- a/web/resources/static/js/moechat_core.js
+++ b/web/resources/static/js/moechat_core.js
@@ -85,6 +85,26 @@ Tips:
 
 */
 
+function appendText(parent, text) {
+  const parts = String(text).split("\n");
+  parts.forEach((part, index) => {
+    if (index > 0) parent.appendChild(document.createElement("br"));
+    parent.appendChild(document.createTextNode(part));
+  });
+}
+
+function normaliseImageUrl(rawUrl) {
+  const trimmed = String(rawUrl).trim();
+  if (trimmed.startsWith("/") && !trimmed.startsWith("//")) return trimmed;
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") return parsed.href;
+  } catch (err) {
+    return null;
+  }
+  return null;
+}
+
 //消息和头像
 function appendMessage(role, text, append = false) {
   const now = new Date();
@@ -92,28 +112,44 @@ function appendMessage(role, text, append = false) {
   const timestamp = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')} ${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}:${String(now.getSeconds()).padStart(2, '0')}`;
   div.className = `message ${role}`;
   const avatar = role === "user" ? "image/user__avatar.png" : "image/bot__avatar.png";
-  const avatarHTML = `<img src="${avatar}" class="avatar ${role}-avatar">`;
+  const avatarImg = document.createElement("img");
+  avatarImg.src = avatar;
+  avatarImg.className = `avatar ${role}-avatar`;
+
+  const bubble = document.createElement("div");
+  bubble.className = "bubble";
+  const timeLabel = document.createElement("small");
+  timeLabel.style.opacity = "0.6";
+  timeLabel.textContent = `[${timestamp}]`;
+  bubble.appendChild(timeLabel);
+  bubble.appendChild(document.createElement("br"));
 
   const imgTagRegex = /\{img\}((https?:\/\/[^\s]+)|\/[^\s]+)/;
   const imgMatch = text.match(imgTagRegex);
 
   if (role === "bot" && imgMatch) {
-    const imgUrl = imgMatch[1]; 
+    const imgUrl = normaliseImageUrl(imgMatch[1]);
     const remainingText = text.replace(imgTagRegex, "").trim();
 
-    div.innerHTML = `${avatarHTML}<div class="bubble">
-                        <small style='opacity: 0.6;'>[${timestamp}]</small><br>
-                        <img src="${imgUrl}" alt="图片加载失败" style="max-width: 90%; border-radius: 8px; margin-top: 5px;">
-                        ${remainingText ? `<br>${remainingText}` : ''}
-                     </div>`;
-  } else {
-    if (role === "user") {
-      div.innerHTML = `${avatarHTML}<div class="bubble"><small style='opacity: 0.6;'>[${timestamp}]</small><br>${text}</div>`;
-    } else {
-      div.innerHTML = `${avatarHTML}<div class="bubble"><small style='opacity: 0.6;'>[${timestamp}]</small><br>${text}</div>`;
+    if (imgUrl) {
+      const image = document.createElement("img");
+      image.src = imgUrl;
+      image.alt = "图片加载失败";
+      image.style.maxWidth = "90%";
+      image.style.borderRadius = "8px";
+      image.style.marginTop = "5px";
+      bubble.appendChild(image);
     }
+    if (remainingText) {
+      bubble.appendChild(document.createElement("br"));
+      appendText(bubble, remainingText);
+    }
+  } else {
+    appendText(bubble, text);
   }
 
+  div.appendChild(avatarImg);
+  div.appendChild(bubble);
   chatLog.appendChild(div);
   chatLog.scrollTop = chatLog.scrollHeight;
 
@@ -634,7 +670,7 @@ function launchRainEffect() {
   window.rainEffectLoaded = true;
 
   const rainScript = document.createElement("script");
-  rainScript.src = "rain_effect.js";
+  rainScript.src = "/js/rain_effect.js";
   rainScript.id = "rainEffectScript";
   document.body.appendChild(rainScript);
 


### PR DESCRIPTION
## Summary
- render chat message text with DOM text nodes instead of injecting user/model text through innerHTML
- construct image messages with DOM APIs and validate supported image URL forms
- fix rain effect and crack overlay static asset paths
- add a lightweight frontend security/static-asset check script

## Verification
- node --check web/resources/static/js/moechat_core.js
- node checks/frontend_security_check.js
- git diff --check