### PR TITLE
Honor memory settings during retrieval and writes

### DIFF
--- a/checks/memory_behavior_check.py
+++ b/checks/memory_behavior_check.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+long_mem = (ROOT / "utils" / "long_mem.py").read_text(encoding="utf-8")
+agent = (ROOT / "utils" / "agent.py").read_text(encoding="utf-8")
+
+
+def fail(message: str) -> None:
+    raise SystemExit(message)
+
+
+if "import pickle" in long_mem:
+    fail("long_mem.py should not import unused pickle")
+if "self._sort_loaded_memories()" not in long_mem:
+    fail("long_mem.py must sort loaded memories before bisect lookup")
+if "range(res_index[0] + 1" in long_mem:
+    fail("long_mem.py still skips the first memory in a matched time range")
+if "if self.enable_core_memory:" not in agent:
+    fail("agent.py must honor enableCoreMemory before writing core memory")
+if "if self.enable_long_memory:" not in agent:
+    fail("agent.py must honor enableLongMemory before writing long memory")

--- a/utils/agent.py
+++ b/utils/agent.py
@@ -411,28 +411,30 @@ class Agent:
         msg_data_tmp = self.msg_data_tmp.copy()
         m1 = msg_data_tmp[-2]["content"]
 
-        try:
-            # 插入核心记忆
-            insert_core_mem_thread = Thread(
-                target=self.insert_core_mem,
-                args=(
-                    m1,
-                    self.msg_data_tmp[-1]["content"],
-                    self.msg_data[-1]["content"],
-                ),
+        if self.enable_core_memory:
+            try:
+                # 插入核心记忆
+                insert_core_mem_thread = Thread(
+                    target=self.insert_core_mem,
+                    args=(
+                        m1,
+                        self.msg_data_tmp[-1]["content"],
+                        self.msg_data[-1]["content"],
+                    ),
+                    daemon=True,
+                )
+
+                insert_core_mem_thread.start()
+            except Exception as e:
+                Log.logger.error(f"核心记忆插入失败：{self.msg_data_tmp}，错误：{e}")
+        if self.enable_long_memory:
+            # 插入记忆
+            add_memory_thread = Thread(
+                target=self.memoryEngine.add_memory1,
+                args=(msg_data_tmp, self.current_time, self.llm_config),
                 daemon=True,
             )
-
-            insert_core_mem_thread.start()
-        except Exception as e:
-            Log.logger.error(f"核心记忆插入失败：{self.msg_data_tmp}，错误：{e}")
-        # 插入记忆
-        add_memory_thread = Thread(
-            target=self.memoryEngine.add_memory1,
-            args=(msg_data_tmp, self.current_time, self.llm_config),
-            daemon=True,
-        )
-        add_memory_thread.start()
+            add_memory_thread.start()
 
         self.msg_data += self.msg_data_tmp
 
@@ -449,4 +451,3 @@ class Agent:
             )
         # 清空临时消息列表
         self.msg_data_tmp = []
-

--- a/utils/long_mem.py
+++ b/utils/long_mem.py
@@ -6,7 +6,6 @@ from utils import embedding, prompt
 from ruamel.yaml import YAML
 from ruamel.yaml.scalarstring import LiteralScalarString
 import numpy as np
-import pickle
 import requests
 import jionlp
 from bisect import bisect_left, bisect_right
@@ -37,10 +36,10 @@ class Memory:
         # self.char_vectors = np.ndarray()
 
         # 加载记忆
-        msg_vectors = []
         self.memories_path = f"./data/agents/{self.agent_id}/memory"
         # 加载记忆
         self._load_all_memories()
+        self._sort_loaded_memories()
         
         Log.logger.info(
             f"共加载{len(self.memories_key)}条记忆...{len(self.vectors)}条记忆向量"
@@ -58,6 +57,17 @@ class Memory:
                 except Exception as e:
                     Log.logger.error(f"【{file_path}】记忆加载失败: {e}")
                     continue
+
+    def _sort_loaded_memories(self):
+        """保持 timestamp 与 vector 同步排序，bisect 检索依赖该顺序。"""
+        if not self.memories_key:
+            return
+        sorted_items = sorted(
+            zip(self.memories_key, self.vectors),
+            key=lambda item: item[0],
+        )
+        self.memories_key = [item[0] for item in sorted_items]
+        self.vectors = [item[1] for item in sorted_items]
 
     def _load_jsonl_file(self, file_path: str):
         """加载jsonl格式的记忆文件"""
@@ -141,7 +151,7 @@ class Memory:
             Log.logger.info(f"深度检索记忆，检索阈值{self.thresholds}")
             q_v = embedding.q2vect([msg])[0]
             tmp_msg = ""
-            for index in range(res_index[0] + 1, res_index[1] + 1):
+            for index in range(res_index[0], res_index[1] + 1):
                 rr = np.dot(self.vectors[index], q_v)
                 if rr >= self.thresholds:
                     tmp_msg += str(self.memories_data[self.memories_key[index]])
@@ -156,7 +166,7 @@ class Memory:
             #     res_msg.append(res_mem)
         else:
             tmp_mem = ""
-            for index in range(res_index[0] + 1, res_index[1] + 1):
+            for index in range(res_index[0], res_index[1] + 1):
                 tmp_mem += str(self.memories_data[self.memories_key[index]])
                 tmp_mem += "\n"
             if len(tmp_mem) > 0:


### PR DESCRIPTION
## Summary
- sort loaded long-memory timestamps and vectors together before bisect-based time range lookup
- include the first matching memory in time range retrieval instead of starting at start_idx + 1
- honor enableCoreMemory before launching core-memory extraction writes
- honor enableLongMemory before launching long-memory summary writes
- remove an unused pickle import from long_mem.py
- add a lightweight behavior check for the memory ordering/toggle invariants

## Verification
- PYTHONDONTWRITEBYTECODE=1 python3 -m compileall utils/long_mem.py utils/agent.py checks/memory_behavior_check.py
- PYTHONDONTWRITEBYTECODE=1 python3 checks/memory_behavior_check.py
- git diff --check