### PR TITLE
Clear backend chat context from UI

### DIFF
--- a/api/chat_api.py
+++ b/api/chat_api.py
@@ -1,10 +1,12 @@
 from fastapi.responses import StreamingResponse
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from models.dto.tts_request import tts_data
 import core.chat_core as chat_core
 from fastapi import Query
+from services.assistant_service import AssistantService
 
 chat_api = APIRouter()
+assistant_service = AssistantService()
 
 
 @chat_api.get("/stream_chat")
@@ -31,6 +33,18 @@ async def tts_api_v2(params: tts_data):
     return StreamingResponse(
         chat_core.text_llm_tts_v2(params), media_type="text/event-stream"
     )
+
+
+@chat_api.post("/chat/context/clear")
+async def clear_chat_context():
+    agent = assistant_service.get_current_assistant()
+    if not agent:
+        raise HTTPException(status_code=404, detail="No current assistant selected")
+    try:
+        agent.clear_chat_context()
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to clear context: {e}")
+    return {"msg": "Chat context cleared"}
 
 
 # # 客户端获取聊天记录

--- a/checks/clear_context_check.py
+++ b/checks/clear_context_check.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+chat_api = (ROOT / "api" / "chat_api.py").read_text(encoding="utf-8")
+agent = (ROOT / "utils" / "agent.py").read_text(encoding="utf-8")
+frontend = (ROOT / "web" / "resources" / "static" / "js" / "moechat_core.js").read_text(
+    encoding="utf-8"
+)
+
+
+def fail(message: str) -> None:
+    raise SystemExit(message)
+
+
+if '"/chat/context/clear"' not in chat_api:
+    fail("chat_api.py must expose a backend context clear endpoint")
+if "agent.clear_chat_context()" not in chat_api:
+    fail("clear endpoint must clear the current assistant runtime context")
+if "def clear_chat_context" not in agent:
+    fail("Agent must implement clear_chat_context")
+for required in ("self.msg_data = []", "self.msg_data_tmp = []", "history.yaml", "context_summary.md"):
+    if required not in agent:
+        fail(f"clear_chat_context is missing: {required}")
+if "fetch('/api/chat/context/clear', { method: 'POST' })" not in frontend:
+    fail("clear button must call the backend context clear endpoint")
+if "清空聊天上下文失败" not in frontend:
+    fail("clear failure must be visible in the UI")

--- a/utils/agent.py
+++ b/utils/agent.py
@@ -448,6 +448,28 @@ class Agent:
                 sort_keys=False,
                 allow_unicode=True,
                 indent=4,
-            )
+        )
         # 清空临时消息列表
         self.msg_data_tmp = []
+
+    def clear_chat_context(self) -> None:
+        """
+        清空当前会话上下文和摘要，不删除长期记忆或核心记忆。
+        """
+        self.msg_data = []
+        self.msg_data_tmp = []
+        self.context_summary = ""
+        self.summary_time = time.time()
+
+        with open(
+            f"./data/agents/{self.agent_name}/history.yaml",
+            "w",
+            encoding="utf-8",
+        ) as f:
+            f.write("")
+        with open(
+            f"./data/agents/{self.agent_name}/context_summary.md",
+            "w",
+            encoding="utf-8",
+        ) as f:
+            f.write("")

--- a/web/resources/static/js/moechat_core.js
+++ b/web/resources/static/js/moechat_core.js
@@ -532,9 +532,19 @@ if (
   }
   // ===========================================
 
-  document.getElementById('clearBtn').addEventListener('click', () => {
-    chatLog.innerHTML = '';
-    lastBotMessageDiv = null;
+  document.getElementById('clearBtn').addEventListener('click', async () => {
+    if (currentEventSource) currentEventSource.close();
+    currentEventSource = null;
+    isHandling = false;
+    try {
+      const res = await fetch('/api/chat/context/clear', { method: 'POST' });
+      if (!res.ok) throw new Error(`clear context failed: ${res.status}`);
+      chatLog.innerHTML = '';
+      lastBotMessageDiv = null;
+    } catch (err) {
+      console.error('Clear context error:', err);
+      appendMessage("bot", "⚠️ 清空聊天上下文失败，请稍后重试。");
+    }
   });
 
   document.getElementById('muteToggle').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- add a backend endpoint to clear the current assistant chat context
- clear in-memory chat context, temporary message buffer, persisted history.yaml, and context_summary.md without deleting long/core memory
- update the clear button to call the backend endpoint before clearing the visible chat log
- surface clear failures in the chat UI instead of silently clearing only the DOM
- add a lightweight check for the clear-context wiring

## Verification
- PYTHONDONTWRITEBYTECODE=1 python3 -m compileall api/chat_api.py utils/agent.py checks/clear_context_check.py
- PYTHONDONTWRITEBYTECODE=1 python3 checks/clear_context_check.py
- node --check web/resources/static/js/moechat_core.js
- git diff --check