### PR TITLE
Wire meme responses into main chat

### DIFF
--- a/checks/meme_runtime_wiring_check.py
+++ b/checks/meme_runtime_wiring_check.py
@@ -1,0 +1,32 @@
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+chat_core = (ROOT / "core" / "chat_core.py").read_text(encoding="utf-8")
+service = (ROOT / "core" / "meme_system" / "emotion_service.py").read_text(
+    encoding="utf-8"
+)
+config = json.loads((ROOT / "core" / "meme_system" / "config.json").read_text())
+
+
+def fail(message: str) -> None:
+    raise SystemExit(message)
+
+
+if "StreamProcessor(emotion_processed=True)" not in chat_core:
+    fail("main chat stream must enable meme processing")
+if "DEFAULT_CONFIG_PATH = Path(__file__).with_name(\"config.json\")" not in service:
+    fail("meme service must resolve its default config relative to the module")
+
+paths = config["paths"]
+if paths["memes_base_dir"] != "web/resources/static/memes/":
+    fail("memes_base_dir must point at the mounted static memes directory")
+if paths["keywords_dir"] != "core/meme_system/":
+    fail("keywords_dir must point at the checked-in keyword JSON files")
+if paths["expression_url_prefix"] != "/memes/":
+    fail("expression_url_prefix must match FastAPI's root static mount")
+
+for path in (paths["memes_base_dir"], paths["keywords_dir"]):
+    if not (ROOT / path).exists():
+        fail(f"configured meme path does not exist: {path}")

--- a/core/chat_core.py
+++ b/core/chat_core.py
@@ -497,7 +497,7 @@ async def text_llm_tts(params: tts_data):
     msg_list_for_llm = await agent.get_msg_data(params.msg[-1]["content"])
 
     # 初始化处理器
-    processor = StreamProcessor()
+    processor = StreamProcessor(emotion_processed=True)
 
     # 创建LLM和TTS任务
     llm_task = asyncio.create_task(

--- a/core/meme_system/config.json
+++ b/core/meme_system/config.json
@@ -6,9 +6,9 @@
   },
 
   "paths": {
-    "memes_base_dir": "/core/meme_system/memes/",
-    "keywords_dir": "/core/meme_system/",
-    "expression_url_prefix": "/web/static/memes/"
+    "memes_base_dir": "web/resources/static/memes/",
+    "keywords_dir": "core/meme_system/",
+    "expression_url_prefix": "/memes/"
   },
 
   "scoring_weights": {

--- a/core/meme_system/emotion_service.py
+++ b/core/meme_system/emotion_service.py
@@ -9,20 +9,23 @@ emotion_service.py - 情感服务主程序
 
 import os
 import json
+from pathlib import Path
 from typing import Optional, Dict, Any
 from .keyword_loader import KeywordLoader
 from .emotion_processor import EmotionProcessor
 
+DEFAULT_CONFIG_PATH = Path(__file__).with_name("config.json")
+
 
 class EmotionService:
-    def __init__(self, config_path: str = "meme_system/config.json"):
+    def __init__(self, config_path: str | os.PathLike | None = None):
         """
         初始化情感服务
 
         Args:
             config_path: 配置文件路径
         """
-        self.config_path = config_path
+        self.config_path = str(config_path or DEFAULT_CONFIG_PATH)
         self.config = {}
         self.keyword_loader = None
         self.emotion_processor = None
@@ -306,7 +309,7 @@ class EmotionService:
 _emotion_service_instance = None
 
 
-def get_emotion_service(config_path: str = "meme_system/config.json") -> EmotionService:
+def get_emotion_service(config_path: str | os.PathLike | None = None) -> EmotionService:
     """
     获取情感服务实例（单例模式）
 


### PR DESCRIPTION
## Summary
- enable meme processing for the main /api/chat streaming path
- resolve the meme system default config relative to core/meme_system instead of the process cwd
- point meme config at checked-in keyword files and the mounted static memes directory
- emit meme image URLs under /memes/, matching the FastAPI static root mount
- add a lightweight check for meme runtime wiring and path consistency

## Verification
- PYTHONDONTWRITEBYTECODE=1 python3 -m compileall core/chat_core.py core/meme_system/emotion_service.py checks/meme_runtime_wiring_check.py
- PYTHONDONTWRITEBYTECODE=1 python3 checks/meme_runtime_wiring_check.py
- python3 - <<'PY'
from core.meme_system.emotion_service import get_emotion_service
service = get_emotion_service()
print(service.config_path)
print(service.initialize())
PY
- git diff --check