### PR TITLE
Align memory editor with runtime schema

### DIFF
--- a/checks/memory_editor_runtime_schema_check.py
+++ b/checks/memory_editor_runtime_schema_check.py
@@ -1,0 +1,136 @@
+import importlib.util
+import json
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+
+def install_fake_flask() -> None:
+    fake_flask = types.ModuleType("flask")
+
+    class FakeFlask:
+        def __init__(self, *args, **kwargs):
+            self.secret_key = None
+
+        def template_filter(self, *args, **kwargs):
+            return lambda fn: fn
+
+        def context_processor(self, fn):
+            return fn
+
+        def route(self, *args, **kwargs):
+            return lambda fn: fn
+
+        def run(self, *args, **kwargs):
+            return None
+
+    fake_flask.Flask = FakeFlask
+    fake_flask.flash = lambda *args, **kwargs: None
+    fake_flask.redirect = lambda target: target
+    fake_flask.render_template = lambda *args, **kwargs: ""
+    fake_flask.request = types.SimpleNamespace(args={}, form={})
+    fake_flask.url_for = lambda endpoint, *args, **kwargs: endpoint
+    sys.modules["flask"] = fake_flask
+
+
+def install_fake_ruamel() -> None:
+    fake_ruamel = types.ModuleType("ruamel")
+    fake_yaml_module = types.ModuleType("ruamel.yaml")
+
+    class FakeYAML:
+        preserve_quotes = True
+        width = 4096
+
+        def load(self, stream):
+            text = stream.read()
+            data = {}
+            current_key = None
+            for raw_line in text.splitlines():
+                if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+                    continue
+                if not raw_line.startswith(" ") and raw_line.endswith(":"):
+                    current_key = raw_line[:-1]
+                    data[current_key] = {}
+                    continue
+                if current_key and raw_line.startswith("  ") and ":" in raw_line:
+                    key, value = raw_line.strip().split(":", 1)
+                    data[current_key][key] = value.strip().strip("'\"")
+            return data
+
+        def dump(self, data, stream):
+            for key, value in data.items():
+                stream.write(f"{key}:\n")
+                for child_key, child_value in value.items():
+                    stream.write(f"  {child_key}: {child_value}\n")
+
+    fake_yaml_module.YAML = FakeYAML
+    sys.modules["ruamel"] = fake_ruamel
+    sys.modules["ruamel.yaml"] = fake_yaml_module
+
+
+def load_memory_editor(repo_root: Path):
+    install_fake_flask()
+    install_fake_ruamel()
+    module_path = repo_root / "data" / "memory_editor_web.py"
+    spec = importlib.util.spec_from_file_location("memory_editor_web_check", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    module = load_memory_editor(repo_root)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        agents_dir = Path(tmp) / "agents"
+        agent_dir = agents_dir / "TestAgent"
+        memory_dir = agent_dir / "memory"
+        memory_dir.mkdir(parents=True)
+        (agent_dir / "info.yaml").write_text("name: TestAgent\n", encoding="utf-8")
+        (agent_dir / "core_mem.yml").write_text(
+            "abc123:\n  time: '2026-05-19 10:00:00'\n  text: 原始核心记忆\n",
+            encoding="utf-8",
+        )
+        long_entry = {
+            "timestamp": 1779184800,
+            "text_tag": "原始标签",
+            "msg": "时间：2026-05-19 10:00:00\n{{user}}：今天吃了苹果\n{{char}}：记住了",
+            "vector": [0.1, 0.2],
+        }
+        (memory_dir / "2026-5-19.jsonl").write_text(
+            json.dumps(long_entry, ensure_ascii=False, separators=(",", ":")) + "\n",
+            encoding="utf-8",
+        )
+
+        editor = module.MemoryEditor(agent_name="TestAgent", agents_dir=agents_dir)
+        assert len(editor.db) == 2
+        assert len(editor.search("苹果", "", "")) == 1
+        assert editor.search("", "2026-05-19", "2026-05-19")
+
+        long_item = next(item for item in editor.db if item["type"] == "long")
+        updated = {**long_item, "data": dict(long_item["data"])}
+        updated["data"]["text_tag"] = "更新标签"
+        updated["data"]["msg"] = "时间：2026-05-19 10:00:00\n{{user}}：今天吃了梨\n{{char}}：记住了"
+        warning = editor.refresh_long_memory_vector(updated, long_item)
+        assert warning and "保留原 vector" in warning
+        editor.save_entry(updated)
+
+        saved_line = (memory_dir / "2026-5-19.jsonl").read_text(encoding="utf-8").strip()
+        saved = json.loads(saved_line)
+        assert saved["text_tag"] == "更新标签"
+        assert saved["vector"] == [0.1, 0.2]
+        assert "梨" in saved["msg"]
+
+        editor.load_all_mems()
+        long_item = next(item for item in editor.db if item["type"] == "long")
+        editor.delete_entry(long_item)
+        assert (memory_dir / "2026-5-19.jsonl").read_text(encoding="utf-8") == ""
+
+    print("memory editor runtime schema check passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/data/memory_editor_web.py
+++ b/data/memory_editor_web.py
@@ -1,469 +1,568 @@
+import json
 import os
 import sys
-from datetime import datetime, time
-from ruamel.yaml import YAML
 import traceback
-import uuid as uuid_generator # 用于生成核心记忆ID
-import time as time_module    # 用于生成长期记忆ID
-import re
+from datetime import datetime, time
+from pathlib import Path
 
-from flask import Flask, render_template, request, redirect, url_for, flash
+from flask import Flask, flash, redirect, render_template, request, url_for
+from ruamel.yaml import YAML
 
-#路径配置
-BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-CORE_MEM_FILE = os.path.join(BASE_DIR, "core_mem.yml")
-LONG_MEM_DIR = os.path.join(BASE_DIR, "memorys")
 
-#MemoryEditor
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+DATA_DIR = PROJECT_ROOT / "data"
+DEFAULT_AGENTS_DIR = DATA_DIR / "agents"
+DEFAULT_AGENT_NAME = "Chat酱"
+ALL_DATES_LABEL = "-- 所有日期 --"
+
+
+def _env_path(name: str, default: Path) -> Path:
+    value = os.environ.get(name, "").strip()
+    return Path(value).expanduser().resolve() if value else default
+
+
+def resolve_default_agent_name(agents_dir: Path | None = None) -> str:
+    """Pick the same per-agent memory tree used by the main runtime."""
+    agents_dir = agents_dir or _env_path("MOECHAT_MEMORY_EDITOR_AGENTS_DIR", DEFAULT_AGENTS_DIR)
+
+    configured = os.environ.get("MOECHAT_MEMORY_EDITOR_AGENT", "").strip()
+    if configured:
+        return configured
+
+    last_used_file = DATA_DIR / "last_used_agent.txt"
+    if last_used_file.exists():
+        last_used = last_used_file.read_text(encoding="utf-8").strip()
+        if last_used:
+            return last_used
+
+    if (agents_dir / DEFAULT_AGENT_NAME / "info.yaml").is_file():
+        return DEFAULT_AGENT_NAME
+
+    for child in sorted(agents_dir.iterdir()) if agents_dir.exists() else []:
+        if child.is_dir() and (child / "info.yaml").is_file():
+            return child.name
+
+    raise FileNotFoundError(f"未找到任何助手配置目录: {agents_dir}")
+
+
 class MemoryEditor:
     """
-    一个离线的记忆后端。
-    负责所有文件的 I/O (加载, 保存, 删除)。
+    Offline editor for the runtime memory layout:
+    data/agents/{agent}/core_mem.yml and data/agents/{agent}/memory/*.jsonl.
     """
-    def __init__(self):
-        self.db = []
+
+    def __init__(self, agent_name: str | None = None, agents_dir: Path | None = None):
         self.yaml = YAML()
         self.yaml.preserve_quotes = True
         self.yaml.width = 4096
+        self.db: list[dict] = []
 
-        if not os.path.exists(CORE_MEM_FILE) or not os.path.exists(LONG_MEM_DIR):
-            print("[错误] 记忆文件或目录未找到。")
-            raise FileNotFoundError("记忆文件或目录未找到。请检查路径配置。")
+        self.agents_dir = agents_dir or _env_path(
+            "MOECHAT_MEMORY_EDITOR_AGENTS_DIR", DEFAULT_AGENTS_DIR
+        )
+        self.agent_name = agent_name or resolve_default_agent_name(self.agents_dir)
+        self.agent_dir = (self.agents_dir / self.agent_name).resolve()
+        self.core_mem_file = self.agent_dir / "core_mem.yml"
+        self.long_mem_dir = self.agent_dir / "memory"
 
+        self._validate_agent_dir()
+        self.long_mem_dir.mkdir(parents=True, exist_ok=True)
         self.load_all_mems()
 
-    def load_all_mems(self):
-        """加载所有记忆"""
+    def _validate_agent_dir(self) -> None:
+        expected_root = self.agents_dir.resolve()
+        if expected_root not in self.agent_dir.parents and self.agent_dir != expected_root:
+            raise ValueError(f"助手目录越界: {self.agent_dir}")
+        if not (self.agent_dir / "info.yaml").is_file():
+            raise FileNotFoundError(
+                f"助手配置不存在: {self.agent_dir / 'info.yaml'}。"
+                "可用 MOECHAT_MEMORY_EDITOR_AGENT 指定要编辑的助手。"
+            )
+
+    def load_all_mems(self) -> None:
+        """Load core and long memories from the selected assistant."""
         self.db.clear()
         error_count = 0
         try:
             error_count += self._load_core_mem()
             error_count += self._load_long_mem()
-            self.db.sort(key=lambda x: (self.get_datetime_from_entry(x) is None, self.get_datetime_from_entry(x)))
-            print(f"--- 记忆加载完成，共 {len(self.db)} 条。加载过程中遇到 {error_count} 个警告。---")
+            self.db.sort(
+                key=lambda item: (
+                    self.get_datetime_from_entry(item) is None,
+                    self.get_datetime_from_entry(item) or datetime.min,
+                )
+            )
+            print(
+                f"--- 已加载助手 {self.agent_name} 的 {len(self.db)} 条记忆，"
+                f"加载过程中遇到 {error_count} 个警告。---"
+            )
         except Exception as e:
             print(f"[严重错误] 加载记忆时发生错误: {e}")
             traceback.print_exc()
             self.db.clear()
 
     def _load_core_mem(self) -> int:
-        """加载核心记忆, 返回警告数量"""
         warnings = 0
-        try:
-            # 文件是否存在
-            if not os.path.exists(CORE_MEM_FILE):
-                 print(f"[警告] 核心记忆文件未找到: {CORE_MEM_FILE}")
-                 return warnings # 或者返回 0
+        if not self.core_mem_file.exists():
+            print(f"[警告] 核心记忆文件未找到: {self.core_mem_file}")
+            return warnings
 
-            with open(CORE_MEM_FILE, 'r', encoding='utf-8') as f:
-                data = self.yaml.load(f)
-            if data:
-                for uuid, entry in data.items():
-                    if isinstance(entry, dict) and 'text' in entry and 'time' in entry:
-                        self.db.append({
-                            'type': 'core', 'id': uuid, 'file': os.path.basename(CORE_MEM_FILE), 'data': entry
-                        })
-                    elif isinstance(uuid, str) and uuid.startswith('#'): pass
-                    else:
-                         print(f"[警告] 跳过核心记忆中格式不正确的条目: ID={uuid}")
-                         warnings += 1
-        except Exception as e:
-            print(f"[错误] 加载核心记忆 {CORE_MEM_FILE} 失败: {e}")
-            raise
+        with self.core_mem_file.open("r", encoding="utf-8") as f:
+            data = self.yaml.load(f) or {}
+
+        if not isinstance(data, dict):
+            print(f"[警告] 核心记忆文件不是字典结构: {self.core_mem_file}")
+            return warnings + 1
+
+        for uuid, entry in data.items():
+            if isinstance(entry, dict) and "text" in entry and "time" in entry:
+                self.db.append(
+                    {
+                        "type": "core",
+                        "id": str(uuid),
+                        "file": self.core_mem_file.name,
+                        "data": entry,
+                    }
+                )
+            elif isinstance(uuid, str) and uuid.startswith("#"):
+                continue
+            else:
+                print(f"[警告] 跳过核心记忆中格式不正确的条目: ID={uuid}")
+                warnings += 1
         return warnings
 
     def _load_long_mem(self) -> int:
-        """加载长期记忆, 返回警告数量"""
         warnings = 0
-        if not os.path.exists(LONG_MEM_DIR):
-             print(f"[警告] 长期记忆目录未找到: {LONG_MEM_DIR}")
-             return warnings
+        if not self.long_mem_dir.exists():
+            print(f"[警告] 长期记忆目录未找到: {self.long_mem_dir}")
+            return warnings
 
-        for root, _, files in os.walk(LONG_MEM_DIR):
-            for file in files:
-                if file.endswith(('.yaml', '.yml')):
-                    file_path = os.path.join(root, file)
-                    try:
-                        with open(file_path, 'r', encoding='utf-8') as f:
-                            data = self.yaml.load(f)
-                        if data:
-                            for timestamp, entry in data.items():
-                                if isinstance(timestamp, int) and isinstance(entry, dict) and 'msg' in entry and 'text_tag' in entry:
-                                    self.db.append({
-                                        'type': 'long', 'id': timestamp, 'file': file, 'data': entry
-                                    })
-                                elif isinstance(timestamp, str) and timestamp.startswith('#'): pass
-                                else:
-                                    print(f"[警告] 跳过长期记忆文件 {file} 中格式不正确的条目: ID={timestamp}")
-                                    warnings += 1
-                    except Exception as e:
-                        print(f"[错误] 加载长期记忆 {file} 失败: {e}")
+        for file_path in sorted(self.long_mem_dir.rglob("*.jsonl")):
+            relative_file = file_path.relative_to(self.long_mem_dir).as_posix()
+            try:
+                with file_path.open("r", encoding="utf-8") as f:
+                    for line_no, line in enumerate(f, start=1):
+                        raw_line = line.strip()
+                        if not raw_line:
+                            continue
+                        try:
+                            data = json.loads(raw_line)
+                        except json.JSONDecodeError as e:
+                            print(
+                                f"[警告] 跳过 {relative_file}:{line_no} 的无效 JSON: {e}"
+                            )
+                            warnings += 1
+                            continue
+
+                        if self._is_valid_long_memory(data):
+                            timestamp = int(data["timestamp"])
+                            self.db.append(
+                                {
+                                    "type": "long",
+                                    "id": f"{relative_file}:{line_no}",
+                                    "file": relative_file,
+                                    "line_no": line_no,
+                                    "data": data,
+                                    "timestamp": timestamp,
+                                }
+                            )
+                        else:
+                            print(
+                                f"[警告] 跳过长期记忆中格式不正确的条目: "
+                                f"{relative_file}:{line_no}"
+                            )
+                            warnings += 1
+            except Exception as e:
+                print(f"[错误] 加载长期记忆 {relative_file} 失败: {e}")
+                warnings += 1
         return warnings
 
-
-    def get_datetime_from_entry(self, entry):
+    @staticmethod
+    def _is_valid_long_memory(data: object) -> bool:
+        if not isinstance(data, dict):
+            return False
+        if "timestamp" not in data or "msg" not in data or "text_tag" not in data:
+            return False
         try:
-            if entry.get('type') == 'core':
-                return datetime.strptime(entry['data']['time'], '%Y-m-d %H:%M:%S')
-            elif entry.get('type') == 'long':
-                return datetime.fromtimestamp(int(entry['id']))
+            int(data["timestamp"])
+        except (TypeError, ValueError):
+            return False
+        return True
+
+    def get_datetime_from_entry(self, entry: dict):
+        try:
+            if entry.get("type") == "core":
+                return datetime.strptime(entry["data"]["time"], "%Y-%m-%d %H:%M:%S")
+            if entry.get("type") == "long":
+                timestamp = entry.get("timestamp", entry["data"].get("timestamp"))
+                return datetime.fromtimestamp(int(timestamp))
         except (ValueError, TypeError, KeyError, OSError):
             return None
+        return None
 
     def get_unique_dates(self) -> list[str]:
-        """获取唯一日期列表"""
         dates = set()
         for entry in self.db:
             dt = self.get_datetime_from_entry(entry)
             if dt:
-                dates.add(dt.strftime('%Y-%m-%d'))
-        sorted_dates = sorted(list(dates))
-        return ["-- 所有日期 --"] + sorted_dates
+                dates.add(dt.strftime("%Y-%m-%d"))
+        return [ALL_DATES_LABEL] + sorted(dates)
 
-    def find_entry_by_id_and_type(self, entry_id, entry_type):
-        """根据 ID 和类型查找内存中的条目"""
-        target_id = entry_id
-        if entry_type == 'long':
-            try:
-                target_id = int(entry_id)
-            except (ValueError, TypeError):
-                return None
-
+    def find_entry_by_id_and_type(self, entry_id: str, entry_type: str):
         for entry in self.db:
-            if entry.get('type') == entry_type and entry.get('id') == target_id:
+            if entry.get("type") == entry_type and str(entry.get("id")) == str(entry_id):
                 return entry
         return None
 
-
     def search(self, keyword, start_date_str, end_date_str):
-                """统一搜索功能 (搜索标签和所有对话行)"""
-                results = self.db
-                kw_lower = keyword.lower() if keyword else None # 预处理关键词
+        """Search tags, core memory text, and long-memory conversation content."""
+        results = self.db
+        kw_lower = keyword.lower() if keyword else None
 
-                # --- 关键词过滤 ---
-                if kw_lower:
-                    temp_results = []
-                    for entry in results:
-                        match = False
-                        if entry.get('type') == 'core':
-                            text = entry['data'].get('text', '').lower()
-                            if kw_lower in text:
-                                match = True
-                        elif entry.get('type') == 'long':
-                            msg = entry['data'].get('msg', '')
-                            text_tag = entry['data'].get('text_tag', '').lower()
-                            
-                            # 1. 搜索标签
-                            if text_tag and kw_lower in text_tag:
-                                match = True
-                            else:
-                                # 2. 搜索所有对话行 (跳过时间戳行)
-                                lines = msg.split('\n')
-                                if len(lines) > 1:
-                                    # 搜索第2行及之后的所有内容
-                                    content_to_search = "\n".join(lines[1:]).lower()
-                                    if kw_lower in content_to_search:
-                                        match = True
-                        if match:
-                            temp_results.append(entry)
-                    results = temp_results
+        if kw_lower:
+            filtered = []
+            for entry in results:
+                match = False
+                if entry.get("type") == "core":
+                    text = entry["data"].get("text", "").lower()
+                    match = kw_lower in text
+                elif entry.get("type") == "long":
+                    msg = entry["data"].get("msg", "")
+                    text_tag = entry["data"].get("text_tag", "").lower()
+                    match = kw_lower in text_tag or kw_lower in msg.lower()
+                if match:
+                    filtered.append(entry)
+            results = filtered
 
-                # --- 日期过滤
-                start_dt, end_dt = None, None
-                if start_date_str and start_date_str != "-- 所有日期 --":
-                    try: start_dt = datetime.combine(datetime.strptime(start_date_str, '%Y-%m-%d'), time.min)
-                    except ValueError: pass
-                if end_date_str and end_date_str != "-- 所有日期 --":
-                    try: end_dt = datetime.combine(datetime.strptime(end_date_str, '%Y-%m-%d'), time.max)
-                    except ValueError: pass
-                if start_dt or end_dt:
-                    results = [
-                        e for e in results
-                        if (dt := self.get_datetime_from_entry(e))
-                        and (not start_dt or dt >= start_dt)
-                        and (not end_dt or dt <= end_dt)
-                    ]
-                return results
-
-    def _save_yaml_data(self, file_path, data):
-        """封装 YAML 保存逻辑"""
-        try:
-            os.makedirs(os.path.dirname(file_path), exist_ok=True)
-            with open(file_path, 'w', encoding='utf-8') as f:
-                self.yaml.dump(data, f)
-        except Exception as e:
-            raise IOError(f"写入文件 {file_path} 失败: {e}")
-
-    def _delete_pkl(self, entry):
-        """封装 PKL 删除逻辑"""
-        if entry.get('type') == 'long':
-            filename = entry.get('file')
-            if filename:
-                pkl_file = filename.replace('.yaml', '.pkl').replace('.yml', '.pkl')
-                pkl_path = os.path.join(LONG_MEM_DIR, pkl_file)
-                if os.path.exists(pkl_path):
-                    try: os.remove(pkl_path); print(f"[调试] 删除了 {pkl_path}")
-                    except Exception as e: print(f"[错误] 删除 {pkl_path} 失败: {e}")
-
-    def save_entry(self, entry):
-        """保存修改或新增的条目"""
-        file_path = self._get_file_path(entry)
-        if not file_path: raise ValueError("无法确定文件路径")
-
-        data = {}
-        if os.path.exists(file_path):
+        start_dt, end_dt = None, None
+        if start_date_str and start_date_str != ALL_DATES_LABEL:
             try:
-                with open(file_path, 'r', encoding='utf-8') as f: data = self.yaml.load(f)
-                if data is None: data = {}
-            except Exception as e:
-                print(f"[警告] 读取文件 {file_path} 失败，将尝试覆盖: {e}")
-                data = {}
+                start_dt = datetime.combine(
+                    datetime.strptime(start_date_str, "%Y-%m-%d"), time.min
+                )
+            except ValueError:
+                pass
+        if end_date_str and end_date_str != ALL_DATES_LABEL:
+            try:
+                end_dt = datetime.combine(
+                    datetime.strptime(end_date_str, "%Y-%m-%d"), time.max
+                )
+            except ValueError:
+                pass
+        if start_dt or end_dt:
+            results = [
+                e
+                for e in results
+                if (dt := self.get_datetime_from_entry(e))
+                and (not start_dt or dt >= start_dt)
+                and (not end_dt or dt <= end_dt)
+            ]
+        return results
 
-        entry_id = entry.get('id')
-        entry_data = entry.get('data')
-        if entry_id is None or entry_data is None: raise ValueError("条目缺少 ID 或数据")
+    def _save_yaml_data(self, file_path: Path, data: dict) -> None:
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        with file_path.open("w", encoding="utf-8") as f:
+            self.yaml.dump(data, f)
 
-        data[entry_id] = entry_data
-        self._save_yaml_data(file_path, data)
-        self._delete_pkl(entry)
+    def _resolve_long_mem_file(self, filename: str) -> Path:
+        file_path = (self.long_mem_dir / filename).resolve()
+        root = self.long_mem_dir.resolve()
+        if root not in file_path.parents and file_path != root:
+            raise ValueError(f"长期记忆文件越界: {filename}")
+        return file_path
 
-    def delete_entry(self, entry):
-        """删除一个条目"""
-        file_path = self._get_file_path(entry)
-        if not file_path or not os.path.exists(file_path):
-            raise FileNotFoundError(f"无法找到要删除的文件: {file_path}")
-
-        with open(file_path, 'r', encoding='utf-8') as f: data = self.yaml.load(f)
-        if data is None: data = {}
-
-        entry_id = entry.get('id')
-        if entry_id is None: raise ValueError("要删除的条目缺少 ID")
-
-        if entry_id in data:
-            del data[entry_id]
-            self._save_yaml_data(file_path, data)
-            self._delete_pkl(entry)
-        else:
-            print(f"[警告] 尝试删除不存在的条目 ID: {entry_id} in file {file_path}")
-    
-    def _get_file_path(self, entry):
-        """获取条目的完整文件路径"""
-        entry_type = entry.get('type')
-        if entry_type == 'core':
-            return CORE_MEM_FILE
-        elif entry_type == 'long':
-            filename = entry.get('file')
-            if filename: return os.path.join(LONG_MEM_DIR, filename)
-        return None
-
-
-# Flask Web
-
-
-app = Flask(__name__)
-app.secret_key = os.urandom(24)
-
-
-from datetime import datetime as dt # 避免与 datetime 模块本身冲突
-
-@app.template_filter('strftime')
-def _jinja2_filter_datetime(date, fmt=None):
-    """Jinja2 filter for formatting dates/timestamps."""
-    if date is None:
-        return "N/A" # 处理 None 值
-
-    # 尝试将 int/float 时间戳转换为 datetime
-    if isinstance(date, (int, float)):
-        try:
-            date = dt.fromtimestamp(date)
-        except (OSError, ValueError): # 处理无效时间戳
-             return "Invalid Timestamp"
-
-    if isinstance(date, dt):
-        # 如果 fmt 为 None 或空字符串，使用默认格式
-        format_string = fmt if fmt else '%Y-%m-%d %H:%M:%S'
-        try:
-            # 移除可能的时区信息，strftime 不处理带时区的对象
-            native_date = date.replace(tzinfo=None)
-            return native_date.strftime(format_string)
-        except ValueError:
-             return "Invalid Date Format" # 处理格式化错误
-
-    # 如果不是有效的日期/时间对象，尝试将其作为字符串返回
-    return str(date)
-
-
-
-# --- 初始化 MemoryEditor
-try:
-    editor = MemoryEditor()
-except FileNotFoundError as e:
-    print(f"[严重] Flask 应用启动失败: {e}")
-    sys.exit(1)
-# ---------------------------------------------
-
-@app.context_processor
-def inject_editor():
-     """将 editor 对象注入到所有模板的上下文中，以便模板可以直接调用其方法"""
-     return dict(editor=editor)
-
-@app.route('/')
-def index():
-    """主页路由，显示搜索栏和结果"""
-    results = []
-    unique_dates = editor.get_unique_dates()
-    return render_template('index.html', results=results, unique_dates=unique_dates)
-
-@app.route('/search')
-def search():
-    """处理搜索请求"""
-    keyword = request.args.get('keyword', '')
-    start_date = request.args.get('start_date', '')
-    end_date = request.args.get('end_date', '')
-
-    try:
-        results = editor.search(keyword, start_date, end_date)
-        unique_dates = editor.get_unique_dates()
-        
-        for entry in results:
-            if entry.get('type') == 'long':
-                entry['generated_preview'] = _generate_long_mem_preview(entry)
-                
-        flash(f"搜索到 {len(results)} 条结果。", "info")
-    except Exception as e:
-        flash(f"搜索时发生错误: {e}", "error")
-        results = []
-        unique_dates = ["-- 所有日期 --"]
-
-    return render_template('index.html',
-                           results=results,
-                           unique_dates=unique_dates,
-                           keyword=keyword,
-                           start_date=start_date,
-                           end_date=end_date)
-
-@app.route('/edit')
-def edit_form():
-    """显示编辑表单"""
-    entry_id = request.args.get('id')
-    entry_type = request.args.get('type')
-
-    if not entry_id or not entry_type:
-        flash("缺少条目 ID 或类型", "error")
-        return redirect(url_for('index'))
-
-    entry = editor.find_entry_by_id_and_type(entry_id, entry_type)
-
-    if not entry:
-        flash(f"未找到要编辑的条目 (ID: {entry_id}, 类型: {entry_type})", "error")
-        return redirect(url_for('index'))
-
-    return render_template('edit.html', entry=entry)
-
-@app.route('/save', methods=['POST'])
-def save_changes():
-    """处理编辑表单的提交"""
-    try:
-        entry_id_str = request.form['id']
-        entry_type = request.form['type']
-        original_file = request.form.get('file', '')
-
-        updated_data = {}
-        original_entry = editor.find_entry_by_id_and_type(entry_id_str, entry_type)
-
-        if not original_entry:
-             raise KeyError(f"无法找到原始条目 (ID: {entry_id_str}, 类型: {entry_type}) 以进行保存")
-
-
-        if entry_type == 'core':
-            entry_id = entry_id_str
-            updated_data['text'] = request.form['text']
-            updated_data['time'] = original_entry['data']['time']
-        elif entry_type == 'long':
-            entry_id = int(entry_id_str)
-            updated_data['text_tag'] = request.form['text_tag']
-            updated_data['msg'] = request.form['msg']
+    def save_entry(self, entry: dict) -> None:
+        if entry.get("type") == "core":
+            self._save_core_entry(entry)
+        elif entry.get("type") == "long":
+            self._rewrite_long_entry(entry, delete=False)
         else:
             raise ValueError("未知的条目类型")
 
+    def delete_entry(self, entry: dict) -> None:
+        if entry.get("type") == "core":
+            self._delete_core_entry(entry)
+        elif entry.get("type") == "long":
+            self._rewrite_long_entry(entry, delete=True)
+        else:
+            raise ValueError("未知的条目类型")
+
+    def _save_core_entry(self, entry: dict) -> None:
+        data = {}
+        if self.core_mem_file.exists():
+            with self.core_mem_file.open("r", encoding="utf-8") as f:
+                data = self.yaml.load(f) or {}
+        if not isinstance(data, dict):
+            raise ValueError(f"核心记忆文件不是字典结构: {self.core_mem_file}")
+        data[entry["id"]] = entry["data"]
+        self._save_yaml_data(self.core_mem_file, data)
+
+    def _delete_core_entry(self, entry: dict) -> None:
+        if not self.core_mem_file.exists():
+            raise FileNotFoundError(f"核心记忆文件不存在: {self.core_mem_file}")
+        with self.core_mem_file.open("r", encoding="utf-8") as f:
+            data = self.yaml.load(f) or {}
+        if entry["id"] in data:
+            del data[entry["id"]]
+            self._save_yaml_data(self.core_mem_file, data)
+        else:
+            raise KeyError(f"核心记忆条目不存在: {entry['id']}")
+
+    def _rewrite_long_entry(self, entry: dict, delete: bool) -> None:
+        filename = entry.get("file")
+        if not filename:
+            raise ValueError("长期记忆条目缺少文件名")
+
+        file_path = self._resolve_long_mem_file(filename)
+        if not file_path.exists():
+            raise FileNotFoundError(f"长期记忆文件不存在: {file_path}")
+
+        target_line_no = int(entry.get("line_no", 0))
+        replaced = False
+        output_lines: list[str] = []
+
+        with file_path.open("r", encoding="utf-8") as f:
+            for line_no, line in enumerate(f, start=1):
+                raw_line = line.strip()
+                if not raw_line:
+                    continue
+                current = json.loads(raw_line)
+                if line_no == target_line_no:
+                    replaced = True
+                    if not delete:
+                        output_lines.append(
+                            json.dumps(
+                                entry["data"],
+                                ensure_ascii=False,
+                                separators=(",", ":"),
+                            )
+                        )
+                    continue
+                output_lines.append(
+                    json.dumps(current, ensure_ascii=False, separators=(",", ":"))
+                )
+
+        if not replaced:
+            raise KeyError(f"长期记忆条目不存在: {entry.get('id')}")
+
+        with file_path.open("w", encoding="utf-8") as f:
+            if output_lines:
+                f.write("\n".join(output_lines) + "\n")
+            else:
+                f.write("")
+
+    def refresh_long_memory_vector(self, updated_entry: dict, original_entry: dict) -> str | None:
+        if updated_entry.get("type") != "long":
+            return None
+
+        old_tag = original_entry.get("data", {}).get("text_tag")
+        new_tag = updated_entry.get("data", {}).get("text_tag")
+        needs_refresh = old_tag != new_tag or "vector" not in updated_entry.get("data", {})
+        if not needs_refresh:
+            return None
+
+        model_path = PROJECT_ROOT / "data" / "models" / "bge-base-zh-v1.5"
+        if not model_path.exists():
+            return "未找到本地 embedding 模型，已保留原 vector；增强检索可能仍按旧标签匹配。"
+
+        try:
+            from sentence_transformers import SentenceTransformer
+
+            model = SentenceTransformer(str(model_path))
+            vector = model.encode([new_tag], normalize_embeddings=True)[0]
+            updated_entry["data"]["vector"] = (
+                vector.tolist() if hasattr(vector, "tolist") else list(vector)
+            )
+        except Exception as e:
+            return f"重新计算 vector 失败，已保留原 vector: {e}"
+
+        return None
+
+
+app = Flask(__name__)
+app.secret_key = os.environ.get("MOECHAT_MEMORY_EDITOR_SECRET", os.urandom(24))
+editor: MemoryEditor | None = None
+
+
+def get_editor() -> MemoryEditor:
+    global editor
+    if editor is None:
+        editor = MemoryEditor()
+    return editor
+
+
+@app.template_filter("strftime")
+def _jinja2_filter_datetime(date, fmt=None):
+    """Jinja2 filter for formatting dates/timestamps."""
+    if date is None:
+        return "N/A"
+    if isinstance(date, (int, float)):
+        try:
+            date = datetime.fromtimestamp(date)
+        except (OSError, ValueError):
+            return "Invalid Timestamp"
+    if isinstance(date, datetime):
+        format_string = fmt if fmt else "%Y-%m-%d %H:%M:%S"
+        try:
+            return date.replace(tzinfo=None).strftime(format_string)
+        except ValueError:
+            return "Invalid Date Format"
+    return str(date)
+
+
+@app.context_processor
+def inject_editor():
+    return dict(editor=get_editor())
+
+
+@app.route("/")
+def index():
+    active_editor = get_editor()
+    results = []
+    unique_dates = active_editor.get_unique_dates()
+    return render_template("index.html", results=results, unique_dates=unique_dates)
+
+
+@app.route("/search")
+def search():
+    active_editor = get_editor()
+    keyword = request.args.get("keyword", "")
+    start_date = request.args.get("start_date", "")
+    end_date = request.args.get("end_date", "")
+
+    try:
+        results = active_editor.search(keyword, start_date, end_date)
+        unique_dates = active_editor.get_unique_dates()
+
+        for entry in results:
+            if entry.get("type") == "long":
+                entry["generated_preview"] = _generate_long_mem_preview(entry)
+
+        flash(f"搜索到 {len(results)} 条结果。", "info")
+    except Exception as e:
+        flash(f"搜索时发生错误: {e}", "error")
+        traceback.print_exc()
+        results = []
+        unique_dates = [ALL_DATES_LABEL]
+
+    return render_template(
+        "index.html",
+        results=results,
+        unique_dates=unique_dates,
+        keyword=keyword,
+        start_date=start_date,
+        end_date=end_date,
+    )
+
+
+@app.route("/edit")
+def edit_form():
+    active_editor = get_editor()
+    entry_id = request.args.get("id")
+    entry_type = request.args.get("type")
+
+    if not entry_id or not entry_type:
+        flash("缺少条目 ID 或类型", "error")
+        return redirect(url_for("index"))
+
+    entry = active_editor.find_entry_by_id_and_type(entry_id, entry_type)
+    if not entry:
+        flash(f"未找到要编辑的条目 (ID: {entry_id}, 类型: {entry_type})", "error")
+        return redirect(url_for("index"))
+
+    return render_template("edit.html", entry=entry)
+
+
+@app.route("/save", methods=["POST"])
+def save_changes():
+    active_editor = get_editor()
+    try:
+        entry_id_str = request.form["id"]
+        entry_type = request.form["type"]
+        original_entry = active_editor.find_entry_by_id_and_type(entry_id_str, entry_type)
+
+        if not original_entry:
+            raise KeyError(
+                f"无法找到原始条目 (ID: {entry_id_str}, 类型: {entry_type}) 以进行保存"
+            )
+
         updated_entry = {
-            'id': entry_id,
-            'type': entry_type,
-            'file': original_file,
-            'data': updated_data
+            **original_entry,
+            "data": dict(original_entry["data"]),
         }
 
-        editor.save_entry(updated_entry)
-        editor.load_all_mems()
-        flash("记忆保存成功！", "success")
+        if entry_type == "core":
+            updated_entry["data"]["text"] = request.form["text"]
+        elif entry_type == "long":
+            updated_entry["data"]["text_tag"] = request.form["text_tag"]
+            updated_entry["data"]["msg"] = request.form["msg"]
+            vector_warning = active_editor.refresh_long_memory_vector(
+                updated_entry, original_entry
+            )
+        else:
+            raise ValueError("未知的条目类型")
 
-    except (ValueError, IOError, KeyError, Exception) as e:
+        active_editor.save_entry(updated_entry)
+        active_editor.load_all_mems()
+        if entry_type == "long" and vector_warning:
+            flash(f"记忆保存成功；{vector_warning}", "warning")
+        else:
+            flash("记忆保存成功！", "success")
+
+    except Exception as e:
         flash(f"保存记忆时出错: {e}", "error")
         traceback.print_exc()
 
-    return redirect(url_for('index'))
+    return redirect(url_for("index"))
 
 
-@app.route('/delete', methods=['POST'])
+@app.route("/delete", methods=["POST"])
 def delete_item():
-    """处理删除请求"""
+    active_editor = get_editor()
     try:
-        entry_id_str = request.form['id']
-        entry_type = request.form['type']
+        entry_id_str = request.form["id"]
+        entry_type = request.form["type"]
 
-
-        entry_to_delete = editor.find_entry_by_id_and_type(entry_id_str, entry_type)
+        entry_to_delete = active_editor.find_entry_by_id_and_type(
+            entry_id_str, entry_type
+        )
         if not entry_to_delete:
-             raise KeyError(f"无法找到要删除的条目 (ID: {entry_id_str}, 类型: {entry_type})")
+            raise KeyError(f"无法找到要删除的条目 (ID: {entry_id_str}, 类型: {entry_type})")
 
-
-        editor.delete_entry(entry_to_delete)
-        editor.load_all_mems() 
+        active_editor.delete_entry(entry_to_delete)
+        active_editor.load_all_mems()
         flash("记忆删除成功！", "success")
 
-    except (FileNotFoundError, ValueError, IOError, KeyError, Exception) as e:
+    except Exception as e:
         flash(f"删除记忆时出错: {e}", "error")
         traceback.print_exc()
 
-    return redirect(url_for('index'))
+    return redirect(url_for("index"))
+
 
 def _generate_long_mem_preview(entry: dict) -> str:
-    """
-    【新版】辅助函数：自动解析并生成 long 记忆的预览字符串。
-    返回包含 <br> 标签的 HTML 字符串，用于前端显示。
-    """
-    msg = entry.get('data', {}).get('msg', '')
-    lines = msg.split('\n')
-    
-    user_line = None
-    ai_line = None
+    msg = entry.get("data", {}).get("msg", "")
+    lines = msg.split("\n")
 
-    # 自动获取第2行 (用户) 和 第3行 (AI) 的完整内容
+    preview_lines = []
     if len(lines) > 1:
-        user_line = lines[1].strip() 
-
+        preview_lines.append(lines[1].strip())
     if len(lines) > 2:
-        ai_line = lines[2].strip() 
+        preview_lines.append(lines[2].strip())
 
-    # 构建预览字符串
-    parts_list = []
-    if user_line: 
-        parts_list.append(user_line)
-    if ai_line: 
-        parts_list.append(ai_line)
-    
-    # 空行
-    preview = "<br><br>".join(parts_list)
-
-    # 备选方案
-    if not preview and len(lines) > 1:
-        preview = lines[1].strip() # 使用第2行原文
-    
-
-    # preview = preview[:80] + ('...' if len(preview) > 80 else '')
-    
-    return preview
+    if not preview_lines and len(lines) > 1:
+        preview_lines.append(lines[1].strip())
+    return "\n\n".join(line for line in preview_lines if line)
 
 
-if __name__ == '__main__':
-    app.run(debug=True, host='0.0.0.0', port=5000)
+if __name__ == "__main__":
+    try:
+        get_editor()
+    except Exception as e:
+        print(f"[严重] Flask 应用启动失败: {e}")
+        traceback.print_exc()
+        sys.exit(1)
+
+    host = os.environ.get("MOECHAT_MEMORY_EDITOR_HOST", "127.0.0.1")
+    port = int(os.environ.get("MOECHAT_MEMORY_EDITOR_PORT", "5051"))
+    app.run(debug=True, host=host, port=port)

--- a/data/templates/base.html
+++ b/data/templates/base.html
@@ -25,6 +25,7 @@
         .flashes .success { background-color: #d4edda; color: #155724; border: 1px solid #c3e6cb; }
         .flashes .error { background-color: #f8d7da; color: #721c24; border: 1px solid #f5c6cb; }
         .flashes .info { background-color: #d1ecf1; color: #0c5460; border: 1px solid #bee5eb; }
+        .flashes .warning { background-color: #fff3cd; color: #856404; border: 1px solid #ffeeba; }
         
         /* 表单样式 (不变) */
         form label, form input, form select, form textarea, form button { display: block; margin-bottom: 10px; width: 95%; }
@@ -100,6 +101,9 @@
             font-size: 0.9em;
             margin: 0; /* 移除按钮的默认边距 */
         }
+        .preview {
+            white-space: pre-line;
+        }
 
          /* 搜索栏样式 (不变) */
         .search-form { display: flex; gap: 10px; align-items: center; margin-bottom: 20px; flex-wrap: wrap;}
@@ -110,7 +114,7 @@
 </head>
 <body>
     <div class="container">
-        <h1>记忆编辑器</h1>
+        <h1>记忆编辑器 - {{ editor.agent_name }}</h1>
 
         {# 显示闪烁消息 (不变) #}
         {% with messages = get_flashed_messages(with_categories=true) %}

--- a/data/templates/index.html
+++ b/data/templates/index.html
@@ -52,15 +52,14 @@
                     {# 使用 Jinja2 的 default 过滤器防止出错 #}
                     <td>{{ editor.get_datetime_from_entry(entry)|default('N/A', true)|strftime('%Y-%m-%d %H:%M:%S') }}</td>
                     <td>{{ entry.type | default('N/A') }}</td>
-                    <td>
-                        {# 内容预览逻辑 (safe 版) #}
+                    <td class="preview">
+                        {# 内容预览逻辑：默认转义用户/助手文本，只用 CSS 保留换行 #}
                         {% if entry.type == 'core' %}
                             {# 核心记忆仍然截断并转义 #}
                             {% set text = entry.data.text | default('') %}
                             {{ text[:80] + ('...' if text|length > 80 else '') }}
                         {% elif entry.type == 'long' %}
-                            {# 【重要】使用 |safe 过滤器来渲染 <br> 标签 #}
-                            {{ entry.generated_preview | default('(预览解析失败)') | safe }}
+                            {{ entry.generated_preview | default('(预览解析失败)') }}
                         {% endif %}
                     </td>
                     <td>{{ entry.data.text_tag if entry.type == 'long' else '' }}</td>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "datasets<3", #数据集处理（无直接使用，依赖）
     "faiss-cpu>=1.12.0", #向量搜索
     "fastapi>=0.116.1", #Web API框架
+    "flask>=3.1.0", #记忆编辑器Web界面
     "funasr>=1.2.7", #语音识别
     "httpx>=0.28.1", #异步HTTP请求库
     "jionlp>=1.5.24", #中文自然语言处理工具包

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ colorlog==6.9.0
 faiss-cpu==1.12.0
 fastapi==0.116.1
 filetype==1.2.0
+flask==3.1.1
 funasr==1.2.7
 httpx==0.28.1
 jionlp==1.5.24


### PR DESCRIPTION
## Summary
- point the memory editor at the per-assistant runtime data tree under data/agents/{agent}
- load/edit/delete long memories from memory/*.jsonl while preserving existing vectors and unknown fields
- keep core memory editing on the runtime core_mem.yml schema
- avoid rendering memory previews as trusted HTML and bind the standalone editor to localhost:5051 by default
- add a lightweight schema check for JSONL load/search/save/delete behavior

## Verification
- PYTHONDONTWRITEBYTECODE=1 python3 checks/memory_editor_runtime_schema_check.py
- PYTHONDONTWRITEBYTECODE=1 python3 -m compileall data/memory_editor_web.py checks/memory_editor_runtime_schema_check.py
- git diff --check