### PR TITLE
Mark financial plugin as standalone opt-in

### DIFF
--- a/checks/financial_plugin_standalone_check.py
+++ b/checks/financial_plugin_standalone_check.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+
+RUNTIME_PATHS = [
+    "api",
+    "core",
+    "utils",
+    "web",
+    "services",
+    "init_server.py",
+    "main_web.py",
+]
+
+
+def assert_financial_config_disabled(repo_root: Path) -> None:
+    config = (repo_root / "plugins" / "financial" / "config.yml").read_text(
+        encoding="utf-8"
+    )
+    assert "enabled: false" in config
+    assert "enabled: true" not in config
+
+
+def assert_balancer_localhost_default(repo_root: Path) -> None:
+    app_py = (repo_root / "plugins" / "financial" / "balancer" / "app.py").read_text(
+        encoding="utf-8"
+    )
+    assert 'MOECHAT_FINANCIAL_HOST", "127.0.0.1"' in app_py
+    assert 'MOECHAT_FINANCIAL_PORT", "5000"' in app_py
+    assert 'app.run(host="0.0.0.0", port=5000' not in app_py
+
+
+def assert_main_runtime_does_not_claim_hook(repo_root: Path) -> None:
+    hits = []
+    for rel_path in RUNTIME_PATHS:
+        path = repo_root / rel_path
+        files = [path] if path.is_file() else path.rglob("*.py")
+        for file_path in files:
+            text = file_path.read_text(encoding="utf-8")
+            if "financial_plugin_hook" in text or "plugins.financial" in text:
+                hits.append(str(file_path.relative_to(repo_root)))
+    assert not hits, f"unexpected main-runtime financial hook references: {hits}"
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    assert_financial_config_disabled(repo_root)
+    assert_balancer_localhost_default(repo_root)
+    assert_main_runtime_does_not_claim_hook(repo_root)
+    print("financial plugin standalone check passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/financial/README.md
+++ b/plugins/financial/README.md
@@ -1,0 +1,38 @@
+# Financial plugin status
+
+The financial recorder is currently a standalone/opt-in plugin. MoeChat's main
+FastAPI chat path does not initialize `financial_plugin_hook()` or inject its
+result into `chat_core`, so setting `financial_plugin.enabled: true` alone does
+not make financial messages visible in the normal chat UI.
+
+## Current runtime shape
+
+- Standalone API/UI: `plugins/financial/balancer/app.py`
+- Plugin hook: `plugins/financial/plugin.py`
+- Default plugin config: `plugins/financial/config.yml`
+- Main chat runtime: `/api/stream_chat` and `/api/chat` call `core.chat_core`
+  directly and do not call the financial hook.
+
+## How to run the standalone recorder
+
+```bash
+cd plugins/financial/balancer
+python app.py
+```
+
+By default the standalone recorder listens on `127.0.0.1:5000`. Override it with:
+
+```bash
+MOECHAT_FINANCIAL_HOST=127.0.0.1 MOECHAT_FINANCIAL_PORT=5050 python app.py
+```
+
+## Enabling integration later
+
+A future integration PR should:
+
+1. add a main-runtime feature flag;
+2. initialize the plugin once during server startup;
+3. call `financial_plugin_hook()` from the chat path;
+4. convert `llm_context` into user-visible chat feedback;
+5. include an end-to-end check where a real chat message records or rejects a
+   transaction through the standalone API.

--- a/plugins/financial/balancer/app.py
+++ b/plugins/financial/balancer/app.py
@@ -4,6 +4,7 @@
 from flask import Flask, request, render_template, jsonify
 from datetime import datetime
 import json
+import os
 
 # 导入自定义模块
 from modules.parser import TransactionParser
@@ -286,8 +287,11 @@ def internal_error(error):
 
 
 if __name__ == "__main__":
+    host = os.environ.get("MOECHAT_FINANCIAL_HOST", "127.0.0.1")
+    port = int(os.environ.get("MOECHAT_FINANCIAL_PORT", "5000"))
+
     print("=== 财务记录系统启动 ===")
-    print("访问地址: http://localhost:5000")
+    print(f"访问地址: http://{host}:{port}")
     print("API文档:")
     print("  POST /api/transaction - 添加交易")
     print("  GET  /api/balance/<账户名> - 查询余额")
@@ -300,4 +304,4 @@ if __name__ == "__main__":
     print("========================")
 
     # 启动Flask应用
-    app.run(host="0.0.0.0", port=5000, debug=True)
+    app.run(host=host, port=port, debug=True)

--- a/plugins/financial/config.yml
+++ b/plugins/financial/config.yml
@@ -1,7 +1,10 @@
 # Financial Plugin Configuration
 financial_plugin:
   # 基础设置
-  enabled: true
+  # Standalone/opt-in by default: MoeChat's main chat runtime does not
+  # initialize this hook yet, so keep the plugin disabled unless an
+  # integration layer explicitly enables and calls it.
+  enabled: false
   name: "财务记录插件"
   version: "1.0.0"
   
@@ -23,5 +26,5 @@ financial_plugin:
     
   # 调试设置
   debug:
-    enabled: true
+    enabled: false
     log_level: "INFO"


### PR DESCRIPTION
## Summary
- disable the financial plugin by default because the main chat runtime does not initialize or call its hook
- document the current standalone runtime shape and the requirements for a future chat integration PR
- bind the standalone balancer to localhost by default and allow host/port overrides via environment variables
- add a lightweight check that the config is opt-in and the main runtime does not claim financial hook integration

## Verification
- PYTHONDONTWRITEBYTECODE=1 python3 checks/financial_plugin_standalone_check.py
- PYTHONDONTWRITEBYTECODE=1 python3 -m compileall plugins/financial/balancer/app.py checks/financial_plugin_standalone_check.py
- git diff --check