### PR TITLE
Document weather as standalone experiment

### DIFF
--- a/checks/weather_standalone_status_check.py
+++ b/checks/weather_standalone_status_check.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+
+def assert_external_router_unmounted(repo_root: Path) -> None:
+    router = (repo_root / "web" / "src" / "router" / "router.py").read_text(
+        encoding="utf-8"
+    )
+    assert "# from core.external_server import router as models_router" in router
+    assert "# app.include_router(models_router, prefix=\"/web\")" in router
+    assert "app.include_router(models_router, prefix=\"/web\")" not in router.replace(
+        "# app.include_router(models_router, prefix=\"/web\")", ""
+    )
+
+
+def assert_main_chat_has_no_weather_hook(repo_root: Path) -> None:
+    chat_core = (repo_root / "core" / "chat_core.py").read_text(encoding="utf-8")
+    assert "HeWeather" not in chat_core
+    assert "get_heweather_dynamic" not in chat_core
+    assert "weather_fetcher" not in chat_core
+
+
+def assert_weather_docs_mark_standalone(repo_root: Path) -> None:
+    readme = (repo_root / "weather" / "README.md").read_text(encoding="utf-8")
+    assert "standalone experimental CLI" in readme
+    assert "not" in readme and "main web chat path" in readme
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    assert_external_router_unmounted(repo_root)
+    assert_main_chat_has_no_weather_hook(repo_root)
+    assert_weather_docs_mark_standalone(repo_root)
+    print("weather standalone status check passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/core/external_server.py
+++ b/core/external_server.py
@@ -1,3 +1,12 @@
+"""
+Legacy experimental router.
+
+This module is not mounted by web/src/router/router.py, so its HeWeather branch
+is not part of the current main chat runtime. Treat it as an experimental
+integration target until configuration, dependencies, static paths, and
+end-to-end /api/stream_chat behavior are wired together in one PR.
+"""
+
 from fastapi import Query, APIRouter
 from fastapi.responses import StreamingResponse, Response, RedirectResponse
 from pydantic import BaseModel

--- a/weather/README.md
+++ b/weather/README.md
@@ -1,0 +1,46 @@
+# Weather module status
+
+The `weather/` directory is a standalone experimental CLI scraper. It is not
+called by MoeChat's main web chat path.
+
+## Current runtime shape
+
+- Main web startup: `main_web.py`
+- Main chat request path: `/api/stream_chat` -> `api/chat_api.py` ->
+  `core.chat_core`
+- Legacy HeWeather branch: `core/external_server.py`
+- Standalone scraper CLI: `weather/main.py`
+
+`web/src/router/router.py` intentionally does not mount `core.external_server`,
+and `core.chat_core` does not call the scraper in `weather/`.
+
+## Standalone CLI usage
+
+```bash
+cd weather
+python main.py 今天天气
+```
+
+Supported commands are:
+
+- `今天天气`
+- `天气`
+- `明天`
+- `后天`
+- `未来一周`
+
+The scraper depends on browser automation packages such as Playwright and
+`playwright-stealth`; those dependencies are not part of the main MoeChat
+runtime dependencies.
+
+## Requirements for a future chat integration
+
+A future weather integration PR should:
+
+1. choose one weather backend (`core.external_server` HeWeather/QWeather API or
+   the `weather/` scraper);
+2. add explicit config and dependency declarations for that backend;
+3. call the backend from the real `/api/stream_chat` path;
+4. surface backend errors in the chat UI instead of silently falling back;
+5. add an end-to-end check where a user-visible chat response changes after a
+   weather query.

--- a/web/src/router/router.py
+++ b/web/src/router/router.py
@@ -4,6 +4,9 @@ from fastapi.staticfiles import StaticFiles
 from web.src.router.api_router import api_router
 from web.src.controller.controller import templates
 
+# Legacy experimental router. It contains HeWeather/image/meme branches, but the
+# main web chat currently uses /api/stream_chat -> core.chat_core instead. Do not
+# mount this router without a dedicated integration pass and end-to-end checks.
 # from core.external_server import router as models_router
 
 app = FastAPI()


### PR DESCRIPTION
## Summary
- mark the legacy external router as experimental and not mounted in the current main chat runtime
- add weather module documentation that distinguishes the standalone scraper from the unmounted HeWeather branch
- add a lightweight check proving /api/stream_chat does not currently call weather code and the external router remains unmounted

## Verification
- PYTHONDONTWRITEBYTECODE=1 python3 checks/weather_standalone_status_check.py
- PYTHONDONTWRITEBYTECODE=1 python3 -m compileall core/external_server.py checks/weather_standalone_status_check.py
- git diff --check